### PR TITLE
Ajout du système de compilation Meson à GL4Dummies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /Windows/*.opensdf
 /Windows/*.sdf
 /Windows/*.user
+build/*
 
 x64
 CMakeFiles

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install -y libegl1-mesa-dev libgles2-mesa-dev
         - sudo apt-get install -y libsdl2-dev
-        - sudo apt-get install -y python3-pip
+        - sudo apt-get install -y python3-pip python3-setuptools
+        - sudo pip3 install -U pip
         - sudo pip3 install meson ninja
     - os: linux
       dist: xenial
@@ -30,7 +31,8 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install -y libegl1-mesa-dev libgles2-mesa-dev
         - sudo apt-get install -y libsdl2-dev
-        - sudo apt-get install -y python3-pip
+        - sudo apt-get install -y python3-pip python3-setuptools
+        - sudo pip3 install --upgrade pip
         - sudo pip3 install meson ninja
 
     # OSX #######################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: c
 sudo: true
 compiler: clang
-python: "3.5"
 
 matrix:
   include:
     # GNU/Linux tests #############################################
     - os: linux
+      dist: xenial
+      python: "3.6"
       addons:
         apt:
           sources:
@@ -21,6 +22,8 @@ matrix:
         - sudo apt-get install -y python3-pip
         - sudo pip3 install meson ninja
     - os: linux
+      dist: xenial
+      python: "3.6"
       compiler: gcc
       before_install:
         - sudo add-apt-repository -y ppa:team-xbmc/ppa

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,18 +19,18 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install -y libegl1-mesa-dev libgles2-mesa-dev
         - sudo apt-get install -y libsdl2-dev
+        - sudo apt-get install -y python3
+        - sudo pip3 install meson ninja
 
     # OSX #######################################################
     - os: osx
       ruby: 2.3
-      osx_image: xcode8
+      osx_image: xcode10.2
       before_install:
-        - brew update && brew install sdl2 libtool autoconf make
-        - sudo ln -s `which glibtoolize` libtoolize
-        - export PATH=$(pwd):$PATH
+        - brew update && brew install sdl2 pip3
+        - pip3 install meson ninja
 
 script:
-  - make -f Makefile.autotools
-  - ./configure
-  - make
-  - sudo make install
+  - meson build
+  - ninja -C build
+  - cd build && sudo meson install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 sudo: true
 compiler: clang
+python: "3.5"
 
 matrix:
   include:
@@ -12,6 +13,13 @@ matrix:
             - llvm-toolchain-precise-3.8
           packages:
             - libsdl2-dev
+      before_install:
+        - sudo add-apt-repository -y ppa:team-xbmc/ppa
+        - sudo apt-get update -qq
+        - sudo apt-get install -y libegl1-mesa-dev libgles2-mesa-dev
+        - sudo apt-get install -y libsdl2-dev
+        - sudo apt-get install -y python3-pip
+        - sudo pip3 install meson ninja
     - os: linux
       compiler: gcc
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - sudo apt-get update -qq
         - sudo apt-get install -y libegl1-mesa-dev libgles2-mesa-dev
         - sudo apt-get install -y libsdl2-dev
-        - sudo apt-get install -y python3
+        - sudo apt-get install -y python3-pip
         - sudo pip3 install meson ninja
 
     # OSX #######################################################
@@ -27,7 +27,8 @@ matrix:
       ruby: 2.3
       osx_image: xcode10.2
       before_install:
-        - brew update && brew install sdl2 pip3
+        - brew update && brew install sdl2 python
+        - python -m pip install --upgrade pip
         - pip3 install meson ninja
 
 script:

--- a/README.md
+++ b/README.md
@@ -1,20 +1,150 @@
-# GL4Dummies
-
 [![Build Status](https://travis-ci.org/noalien/GL4Dummies.svg?branch=master)](https://travis-ci.org/noalien/GL4Dummies)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/763511e61710449e841821bafbd346e6)](https://www.codacy.com/app/Phundrak/GL4Dummies?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=noalien/GL4Dummies&amp;utm_campaign=Badge_Grade)
 [![CodeFactor](https://www.codefactor.io/repository/github/noalien/gl4dummies/badge)](https://www.codefactor.io/repository/github/noalien/gl4dummies)
 [![Documentation](http://phundrak.fr/img/docs-doxygen-blue.svg)](http://gl4d.api8.fr/doxygen/html/files.html)
 
-## Installation
+# GL4Dummies
+GL4Dummies is a C wrapper around OpenGL that aims to help C developers to easily
+produce Multi-platform OpenGL 3.3+ applications.
 
-In order to launch autotools config, type `make -f Makefile.autotools`. The following packages are required:
+# Installation
+
+Two different build systems are available for GL4Dummies: the Meson build system
+and Autotools. While the former offers a faster compile time and pkg-config
+files for an easier setup of your projects using GL4Dummies, its implementation
+in this project is still experimental and does not support (yet) Windows builds
+–though you can try to make it work, and if you succeed do not hesitate to
+submit a pull request!
+
+## Dependencies
+GL4Dummies has two dependencies: OpenGL and the SDL2. You will at least need to
+install the SDL development package to get GL4Dummies running. You can install
+it with your favorite package manager if you have access to one. Here are some
+common names for the package you will need for the SDL:
+- `libsdl2-dev` on Linux distros based on Debian (including Ubuntu)
+- `sdl2` on distros based on Arch Linux
+- `SDL2-devel` on Void Linux
+- `sdl2-dev` on Alpine Linux
+- `libsdl2` with MacPorts on macOS
+- `sdl2` with HomeBrew on macOS
+
+## Meson
+To compile this project with project with Meson, you will need to install at
+least three packages:
+- Python3 and pip3
+- Meson
+- Ninja
+
+To install Python3 and pip3, follow the instructions of your Linux distribution.
+On macOS machines, pip will already be installed if you have already installed
+Python3, same goes for Windows. For the former, check that the binaries from pip
+are in your Path variable.
+
+### With superuser rights
+If you have superuser rights on your machine and you want to install this
+project globally, go to the project's root and run the following:
+```sh
+meson build
+cd build
+ninja
+sudo meson install
+```
+
+You will also need to add `/usr/local/lib/pkgconfig` to your `$PKG_CONFIG_PATH`,
+often by editing your `.profile`, `.bash_profile`, or `.bashrc`. You can do so
+by running the following command (edit it accordingly):
+```sh
+echo "export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/" >> ~/.bashrc && source ~/.bashrc
+```
+
+If you are using fish, you can run this instead:
+```fish
+echo "set -gx PKG_CONFIG_PATH /usr/local/lib/pkgconfig/" >> ~/.config/fish/config.fish; and source ~/.config/fish/config.fish
+```
+
+### Without superuser rights
+If you do not have any superuser rights, or wish to install locally GL4Dummies,
+you can instead run the following:
+```sh
+meson build --prefix /path/to/install/dir
+cd build
+ninja
+meson install
+```
+
+You will also need to add `/path/to/install/dir/lib/pkgconfig` to your
+`$PKG_CONFIG_PATH`, often by editing your `.profile`, `~./.bash_profile`, or
+`~/.bashrc`. You can do so by running the following command (edit it
+accordingly):
+```sh
+echo "export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/local/lib" >> ~/.bashrc && source ~/.bashrc
+```
+
+If you are using fish, you can run this instead:
+```fish
+echo "set -gx PKG_CONFIG_PATH /path/to/install/dir/lib/pkgconfig/" >> ~/.config/fish/config.fish; and source ~/.config/fish/config.fish
+```
+
+## GNU Autotools
+In order to launch autotools config, type `make -f Makefile.autotools`. The
+following packages are required:
 - `automake`
 - `autoconf`
 - `libtool`
 - `make`
 
-Once done, read the manual for installation.
-- [PDF version](http://gl4d.api8.fr/FR/gl4d.pdf)
-- [HTML version](http://gl4d.api8.fr/FR/gl4d.html)
+You can then run the following command:
+```sh
+make -f Makefile.autotools
+```
 
-Under the Windows Operating System, please use CodeBlocks files in the Windows directory.
+### With superuser rights
+If you have superuser rights and wish to install globally GL4Dummies, you can
+run the following commands:
+```sh
+./configure
+make # you can also run `make -j` for parallel compilation
+sudo make install
+```
+
+You will then need to edit your `.profile`, `.bash_profile`, or your `.bashrc`
+and add the following line:
+```bash
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+```
+Or, if you use fish, edit your `~/.config/fish/config.fish` file and add the
+following line:
+```fish
+set -gx LD_LIBRARY_PATH /usr/local/lib $LD_LIBRARY_PATH
+```
+
+### Without superuser rights
+If you do not have superuser rights on your machine, or if you want to install
+GL4Dummies locally, you can run the following instead:
+```sh
+[ -d $HOME/local ] || mkdir $HOME/local
+./configure --prefix=$HOME/local
+make
+make install
+```
+You will then need to add to your `.profile`, `.bash_profile`, or `.bashrc` the
+following lines:
+```bash
+export PATH=$HOME/local/bin:$PATH
+export LD_LIBRARY_PATH=$HOME/local/lib:$LD_LIBRARY_PATH
+```
+
+And if you use fish, you will instead need to add the following lines to your
+`~/.config/fish/config.fish` file:
+```fish
+set -gx PATH $HOME/local/bin $PATH
+set -gx LD_LIBRARY_PATH $HOME/local/lib $LD_LIBRARY_PATH
+```
+
+## Online instructions
+You can also refer to the manual ([PDF](http://gl4d.api8.fr/FR/gl4d.pdf) /
+[HTML](http://gl4d.api8.fr/FR/gl4d.html)) for more in-depth instructions (in
+French).
+
+Under the Windows Operating System, please use CodeBlocks files in the Windows
+directory.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ On macOS machines, pip will already be installed if you have already installed
 Python3, same goes for Windows. For the former, check that the binaries from pip
 are in your Path variable.
 
+First, check which version of pip is the default:
+```sh
+pip --version
+```
+
+If it mentions Python3, you are free to simply use `pip`. Otherwise, verify if
+`pip3` is installed, and if yes use it instead. You can install both Meson and
+Ninja in one go:
+```sh
+pip install meson ninja
+```
+If you experience right issues with the above command, either add the option
+`--user` after `install` to install it locally, or re-run the command with
+`sudo` if you have the rights to do so and if you wish to install these tools
+globally.
+
+Alternatively, you can use your operating system’s package manager if packages
+for these tools exist.
+
 ### With superuser rights
 If you have superuser rights on your machine and you want to install this
 project globally, go to the project's root and run the following:

--- a/lib_src/GL4D/gl4da.h
+++ b/lib_src/GL4D/gl4da.h
@@ -11,7 +11,7 @@
 #define __GL4DA_H__
 
 //#include "gl4dq.h"
-#include <GL4D/gl4dq.h>
+#include "gl4dq.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib_src/GL4D/gl4dfBlur.c
+++ b/lib_src/GL4D/gl4dfBlur.c
@@ -5,7 +5,7 @@
  *
  * \author Farès BELHADJ amsi@ai.univ-paris8.fr
  * \date April 14, 2016
- * 
+ *
  */
 #include <math.h>
 #include <stdio.h>
@@ -67,7 +67,8 @@ static void blurffunc(GLuint in, GLuint out, GLuint radius, GLuint nb_iterations
     gl4dfConvFrame2Tex(&_tempTexId[0]);
   }
   if(out == 0) { /* Pas de sortie, donc sortie aux dimensions du viewport */
-    w = vp[2];// - vp[0]; 
+
+    w = vp[2];// - vp[0];
     h = vp[3];// - vp[1];
     fcommMatchTex(rout = _tempTexId[1], out);
   } else {
@@ -75,7 +76,7 @@ static void blurffunc(GLuint in, GLuint out, GLuint radius, GLuint nb_iterations
     glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
     glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
   }
-  if(w != _width || h != _height)
+  if((GLuint)w != _width || (GLuint)h != _height)
     setDimensions(w, h);
   fcommMatchTex(_tempTexId[2], rout);
 
@@ -132,7 +133,8 @@ static void blurffunc(GLuint in, GLuint out, GLuint radius, GLuint nb_iterations
 }
 
 static void init(void) {
-  GLint vp[4], ctex, i;
+  GLint vp[4], ctex;
+  GLuint i;
   glGetIntegerv(GL_TEXTURE_BINDING_2D, &ctex);
   if(!_tempTexId[0])
     glGenTextures((sizeof _tempTexId / sizeof *_tempTexId), _tempTexId);
@@ -194,7 +196,7 @@ static void init(void) {
 
 static void setDimensions(GLuint w, GLuint h) {
   int i;
-  _width  = w; 
+  _width  = w;
   _height = h;
   for(i = 0; i < BLUR_MAX_RADIUS; i++) {
     _offsetH[(i << 1) + 0] = i / (GLfloat)_width;

--- a/lib_src/GL4D/gl4dfCanny.c
+++ b/lib_src/GL4D/gl4dfCanny.c
@@ -5,7 +5,7 @@
  *
  * \author Farès BELHADJ amsi@ai.univ-paris8.fr
  * \date March 08, 2019
- * 
+ *
  */
 #include <math.h>
 #include <stdio.h>
@@ -144,7 +144,7 @@ static void cannyffunc(GLuint in, GLuint out, GLboolean flipV) {
     gl4dgDraw(fcommGetPlane());
     glBindTexture(GL_TEXTURE_2D, 0);
     glDrawBuffers(1, buffers);
-    
+
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _tempTexId[4],  0);
     glUseProgram(_cannyPId[1]);
     glUniform1i(glGetUniformLocation(_cannyPId[1],  "len"), 0);
@@ -257,7 +257,8 @@ static void cannyffunc(GLuint in, GLuint out, GLboolean flipV) {
 }
 
 static void init(void) {
-  GLint i, ctex;
+  GLint ctex;
+  GLuint i;
   glGetIntegerv(GL_TEXTURE_BINDING_2D, &ctex);
   if(!_tempTexId[0])
     glGenTextures((sizeof _tempTexId / sizeof *_tempTexId), _tempTexId);

--- a/lib_src/GL4D/gl4dfCommon.c
+++ b/lib_src/GL4D/gl4dfCommon.c
@@ -6,7 +6,7 @@
  *
  * \author Farès BELHADJ amsi@ai.univ-paris8.fr
  * \date May 27, 2016
- * 
+ *
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -23,8 +23,10 @@ MKFWINIT0(plane, GLuint);
 static void init(void) {
   GLint ctex;
   glGetIntegerv(GL_TEXTURE_BINDING_2D, &ctex);
-  if(gl4dfBasicVS)
-    ; /* éviter des warnings stupides */
+  if(gl4dfBasicVS) {
+    (void)ctex; /* avoid stupid warning */
+  }
+
   if(!_plan) {
     _plan = gl4dgGenQuadf();
     gl4duAtExit(quit);
@@ -46,15 +48,15 @@ void fcommMatchTex(GLuint goal, GLuint orig) {
   if(orig) {
     glBindTexture(GL_TEXTURE_2D, orig);
     glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
-    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);    
+    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
   } else {
     glGetIntegerv(GL_VIEWPORT, vp);
-    w = vp[2];// - vp[0]; 
+    w = vp[2];// - vp[0];
     h = vp[3];// - vp[1];
   }
   glBindTexture(GL_TEXTURE_2D, goal);
   glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &pw);
-  glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &ph);    
+  glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &ph);
   if(pw != w || ph != h)
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
   glBindTexture(GL_TEXTURE_2D, (GLuint)ctex);

--- a/lib_src/GL4D/gl4dfFractalPainting.c
+++ b/lib_src/GL4D/gl4dfFractalPainting.c
@@ -16,9 +16,9 @@
  * plus efficace.
 */
 #include <assert.h>
-#include <GL4D/gl4du.h>
-#include <GL4D/gl4df.h>
-#include <GL4D/gl4dfCommon.h>
+#include "gl4du.h"
+#include "gl4df.h"
+#include "gl4dfCommon.h"
 
 static inline int nbLevels(int w, int h);
 static int  mdTexData(unsigned int w, unsigned int h);
@@ -48,14 +48,14 @@ void gl4dfMCMD(GLuint in, GLuint out, GLboolean flipV) {
 
 void gl4dfMCMDDimensions(GLuint width, GLuint height) {
   int d = (int)ceil(log(width) / log(2.0));
-  if(width != (1 << d)) {
+  if(width != (GLuint)(1 << d)) {
     fprintf(stderr,
       "%s:%d: les dimensions du MCMD sont des puissances de 2. Conversion a la puissance de 2 superieure.\n",
       __FILE__, __LINE__);
     width = (1 << d);
   }
   d = (int)ceil(log(height) / log(2.0));
-  if(height != (1 << d)) {
+  if(height != (GLuint)(1 << d)) {
     fprintf(stderr,
       "%s:%d: les dimensions du MCMD sont des puissances de 2. Conversion a la puissance de 2 superieure.\n",
       __FILE__, __LINE__);
@@ -689,13 +689,13 @@ static const char * gl4dfMCMD_mdbuV1FSOld =
      }";
 
 static void init(void) {
-  int i;
+  unsigned int i;
   if(!_mdTexId[0])
     glGenTextures(4, _mdTexId);
   if(!_tempTexId[0])
     glGenTextures((sizeof _tempTexId / sizeof *_tempTexId), _tempTexId);
   _maxLevel = mdTexData(_width, _height);
-  for(i = 0; i < (sizeof _tempTexId / sizeof *_tempTexId); i++) {
+  for(i = 0; i < (sizeof _tempTexId / sizeof *_tempTexId); ++i) {
     glBindTexture(GL_TEXTURE_2D, _tempTexId[i]);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
@@ -954,7 +954,8 @@ static void (*_subdivision_func[])(GLubyte *, GLubyte *, ll_t **, GLushort, GLus
 
 
 static void subdivision2Tex(GLubyte ** parentData, GLubyte ** levelData, GLushort ** childData, GLuint * childDataSize, GLubyte ** childPos, unsigned int w, unsigned int h) {
-  int i, l, sl, maxsl = 0, n;
+  int sl, maxsl = 0;
+  unsigned int i, l, n;
   ll_t ** llmap = llMapNew(w, h);
   *parentData = malloc(4 * w * 4 * h * sizeof ** parentData); assert(*parentData);
   *levelData = malloc(w * h * sizeof ** levelData); assert(*levelData);
@@ -987,7 +988,8 @@ static void subdivision2Tex(GLubyte ** parentData, GLubyte ** levelData, GLushor
 }
 
 static int mdTexData(unsigned int w, unsigned int h) {
-  int i, l = 0;
+  int l = 0;
+  unsigned int i;
   GLushort * childData;
   GLubyte * childPos, * parentData = NULL, * levelData = NULL;
 

--- a/lib_src/GL4D/gl4dfFractalPainting.c
+++ b/lib_src/GL4D/gl4dfFractalPainting.c
@@ -301,391 +301,391 @@ void gl4dMCMDSetUseNoiseTranslateMap(GLuint map_tex_id) {
 
 static const char * gl4dfMCMD_select4mcmdFS =
   "<imfs>gl4dfMCMD_select4mcmd.fs</imfs>\n\
-     #version 330\n							\
-     in vec2 vsoTexCoord;\n						\
-     out vec4 fragColor;\n						\
-     uniform int width, height;\n					\
-     uniform sampler2D etage0;\n					\
-     uniform float rand_threshold;\n					\
-     const int ossize = 9;\n						\
-     const vec2 G[ossize] = vec2[]( vec2(1.0,  1.0), vec2(0.0,  2.0), vec2(-1.0,  1.0), \n \
-                 vec2(2.0,  0.0), vec2(0.0,  0.0), vec2(-2.0,  0.0), \n \
-                 vec2(1.0, -1.0), vec2(0.0, -2.0), vec2(-1.0, -1.0) );\n \
-     vec2 step = vec2(1.0 / float(width - 1), 1.0 / float(height - 1));\n \
-     vec2 offset[ossize] = vec2[](vec2(-step.x , -step.y), vec2( 0.0, -step.y), vec2( step.x , -step.y), \n \
-               vec2(-step.x, 0.0),       vec2( 0.0, 0.0),      vec2( step.x, 0.0), \n \
-               vec2(-step.x,   step.y), vec2( 0.0, step.y),  vec2( step.x ,  step.y));\n \
-     float luminance(vec3 rgb) {\n					\
-       return dot(vec3(0.299, 0.587, 0.114), rgb);\n			\
-     }\n								\
-     highp float rand(vec2 co) {\n					\
-       highp float a = 12.9898;\n					\
-       highp float b = 78.233;\n					\
-       highp float c = 43758.5453;\n					\
-       highp float dt= dot(co.xy ,vec2(a,b));\n				\
-       highp float sn= mod(dt,3.14);\n					\
-       return fract(sin(sn) * c);\n					\
-     }\n								\
-     float sobel(void) {\n						\
-       vec2 g = vec2(0.0, 0.0);\n					\
-       for(int i = 0; i < ossize; i++)\n				\
-         g += luminance(texture(etage0, vsoTexCoord.st + offset[i]).rgb) * G[i];\n \
-       return 1.0 - length(g);\n					\
-     }\n								\
-     float sobelFromMedia(void) {\n					\
-       vec2 g = vec2(0.0, 0.0);\n					\
-       for(int i = 0; i < ossize; i++)\n				\
-         g += pow(texture(etage0, vsoTexCoord.st + offset[i]).a, 2.99) * G[i];\n \
-       return 1.0 - length(g);\n					\
-     }\n								\
-     const vec3 minc = vec3(1.0 / 255.0);\n				\
-     void main() {\n							\
-       if((rand(vsoTexCoord.st) > rand_threshold) || 0.2 * sobel() < 0.15 || sobelFromMedia() < 0.1)\n \
-         fragColor = vec4(max(texture(etage0, vsoTexCoord.st).rgb, minc), 1.0);\n \
-       else\n								\
+     #version 330\n\
+     in vec2 vsoTexCoord;\n\
+     out vec4 fragColor;\n\
+     uniform int width, height;\n\
+     uniform sampler2D etage0;\n\
+     uniform float rand_threshold;\n\
+     const int ossize = 9;\n\
+     const vec2 G[ossize] = vec2[]( vec2(1.0,  1.0), vec2(0.0,  2.0), vec2(-1.0,  1.0), \n\
+                 vec2(2.0,  0.0), vec2(0.0,  0.0), vec2(-2.0,  0.0), \n\
+                 vec2(1.0, -1.0), vec2(0.0, -2.0), vec2(-1.0, -1.0) );\n\
+     vec2 step = vec2(1.0 / float(width - 1), 1.0 / float(height - 1));\n\
+     vec2 offset[ossize] = vec2[](vec2(-step.x , -step.y), vec2( 0.0, -step.y), vec2( step.x , -step.y), \n\
+               vec2(-step.x, 0.0),       vec2( 0.0, 0.0),      vec2( step.x, 0.0), \n\
+               vec2(-step.x,   step.y), vec2( 0.0, step.y),  vec2( step.x ,  step.y));\n\
+     float luminance(vec3 rgb) {\n\
+       return dot(vec3(0.299, 0.587, 0.114), rgb);\n\
+     }\n\
+     highp float rand(vec2 co) {\n\
+       highp float a = 12.9898;\n\
+       highp float b = 78.233;\n\
+       highp float c = 43758.5453;\n\
+       highp float dt= dot(co.xy ,vec2(a,b));\n\
+       highp float sn= mod(dt,3.14);\n\
+       return fract(sin(sn) * c);\n\
+     }\n\
+     float sobel(void) {\n\
+       vec2 g = vec2(0.0, 0.0);\n\
+       for(int i = 0; i < ossize; i++)\n\
+         g += luminance(texture(etage0, vsoTexCoord.st + offset[i]).rgb) * G[i];\n\
+       return 1.0 - length(g);\n\
+     }\n\
+     float sobelFromMedia(void) {\n\
+       vec2 g = vec2(0.0, 0.0);\n\
+       for(int i = 0; i < ossize; i++)\n\
+         g += pow(texture(etage0, vsoTexCoord.st + offset[i]).a, 2.99) * G[i];\n\
+       return 1.0 - length(g);\n\
+     }\n\
+     const vec3 minc = vec3(1.0 / 255.0);\n\
+     void main() {\n\
+       if((rand(vsoTexCoord.st) > rand_threshold) || 0.2 * sobel() < 0.15 || sobelFromMedia() < 0.1)\n\
+         fragColor = vec4(max(texture(etage0, vsoTexCoord.st).rgb, minc), 1.0);\n\
+       else\n\
          fragColor = vec4(0.0, 0.0, 0.0, 1.0);\n			\
      }";
 
 static const char * gl4dfMCMD_mdFS =
   "<imfs>gl4dfMCMD_md.fs</imfs>\n\
-     #version 330\n							\
-     in vec2 vsoTexCoord;\n						\
-     out vec4 fragColor;\n						\
-     uniform int width, height, level, maxLevel;\n			\
-     uniform sampler2D etage0, etage1, etage2;\n			\
-     uniform float seed;\n						\
-     uniform vec4 mcmd_noise_H, mcmd_noise_S, mcmd_noise_T, mcmd_noise_phase_change, mcmd_I;\n \
-     vec2[4] getParents(vec2 st) {\n					\
-       int i, x;\n							\
-       vec2 p[4];\n							\
-       vec4 c;\n							\
-       for(i = 0; i < 4; i++) {\n					\
-         x = i + int((st.s * float(width) - 0.5 /*transforme le nearest en floor*/) * 4.0);\n \
-         c = texture(etage1, vec2(float(x) / (float(width) * 4.0), st.t));\n \
-         p[i].x = (int(c.r * 255.0) << 8) | int(c.g * 255.0);\n		\
-         p[i].y = (int(c.b * 255.0) << 8) | int(c.a * 255.0);\n		\
-       }\n								\
-       return p;\n							\
-     }\n								\
-     highp float rand(vec2 co) {\n					\
-       highp float a = 12.9898;\n					\
-       highp float b = 78.233;\n					\
-       highp float c = 43758.5453;\n					\
-       highp float dt= dot(co.xy ,vec2(a,b));\n				\
-       highp float sn= mod(dt,3.14);\n					\
-       return 2.0 * fract(sin(sn) * c) - 1.0;\n				\
-     }\n								\
-     highp vec4 rand(vec2 co, vec4 s) {\n				\
-       return vec4(rand(co + vec2(s.x)), rand(co + vec2(s.y)), rand(co + vec2(s.z)), rand(co + vec2(s.w)));\n \
-     }\n								\
-     void main() {\n							\
-       const vec4 minc = vec4(1.0 / 255.0);\n				\
-       int myLevel = int(texture(etage2, vsoTexCoord.st).r * 255.0);\n	\
-       if(myLevel == level && texture(etage0, vsoTexCoord.st).r == 0.0) {\n \
-         const float maxdist = sqrt(2.0) / 2.0;\n				\
-         float sumw = 0.0, w;\n						\
-         vec4 I_sign = vec4(mcmd_I.x < 0.0 ? -1.0 : 1.0, mcmd_I.y < 0.0 ? -1.0 : 1.0, mcmd_I.z < 0.0 ? -1.0 : 1.0, mcmd_I.w < 0.0 ? -1.0 : 1.0);\n \
-         vec4 I_abs = abs(mcmd_I), v = vec4(0.0);\n			\
-         vec2[4] parents = getParents(vsoTexCoord.st);\n		\
-         for(int i = 0; i < 4; i++) {\n					\
-           if(parents[i].x != 65535) {\n				\
-             vec2 p = vec2(parents[i].x / width , parents[i].y / height);\n \
-             w = 1.0 - length(p - vsoTexCoord) / maxdist;\n		\
-             v += w * (vec4(1.0) - I_sign * (vec4(1.0) - pow(vec4(w), I_abs))) * texture(etage0, p);\n \
-             sumw += w;\n						\
-           }\n								\
-         }\n								\
-         if(sumw > 0.0)\n						\
-           v /= sumw;\n							\
-         v += pow(vec4(2.0), vec4(-(myLevel + 1) * mcmd_noise_H)) * (mcmd_noise_S * (mcmd_noise_T + rand(vsoTexCoord.st + vec2(seed), mcmd_noise_phase_change)));\n \
-         fragColor = max(v, minc);\n					\
-       } else\n								\
+     #version 330\n\
+     in vec2 vsoTexCoord;\n\
+     out vec4 fragColor;\n\
+     uniform int width, height, level, maxLevel;\n\
+     uniform sampler2D etage0, etage1, etage2;\n\
+     uniform float seed;\n\
+     uniform vec4 mcmd_noise_H, mcmd_noise_S, mcmd_noise_T, mcmd_noise_phase_change, mcmd_I;\n\
+     vec2[4] getParents(vec2 st) {\n\
+       int i, x;\n\
+       vec2 p[4];\n\
+       vec4 c;\n\
+       for(i = 0; i < 4; i++) {\n\
+         x = i + int((st.s * float(width) - 0.5 /*transforme le nearest en floor*/) * 4.0);\n\
+         c = texture(etage1, vec2(float(x) / (float(width) * 4.0), st.t));\n\
+         p[i].x = (int(c.r * 255.0) << 8) | int(c.g * 255.0);\n\
+         p[i].y = (int(c.b * 255.0) << 8) | int(c.a * 255.0);\n\
+       }\n\
+       return p;\n\
+     }\n\
+     highp float rand(vec2 co) {\n\
+       highp float a = 12.9898;\n\
+       highp float b = 78.233;\n\
+       highp float c = 43758.5453;\n\
+       highp float dt= dot(co.xy ,vec2(a,b));\n\
+       highp float sn= mod(dt,3.14);\n\
+       return 2.0 * fract(sin(sn) * c) - 1.0;\n\
+     }\n\
+     highp vec4 rand(vec2 co, vec4 s) {\n\
+       return vec4(rand(co + vec2(s.x)), rand(co + vec2(s.y)), rand(co + vec2(s.z)), rand(co + vec2(s.w)));\n\
+     }\n\
+     void main() {\n\
+       const vec4 minc = vec4(1.0 / 255.0);\n\
+       int myLevel = int(texture(etage2, vsoTexCoord.st).r * 255.0);\n\
+       if(myLevel == level && texture(etage0, vsoTexCoord.st).r == 0.0) {\n\
+         const float maxdist = sqrt(2.0) / 2.0;\n\
+         float sumw = 0.0, w;\n\
+         vec4 I_sign = vec4(mcmd_I.x < 0.0 ? -1.0 : 1.0, mcmd_I.y < 0.0 ? -1.0 : 1.0, mcmd_I.z < 0.0 ? -1.0 : 1.0, mcmd_I.w < 0.0 ? -1.0 : 1.0);\n\
+         vec4 I_abs = abs(mcmd_I), v = vec4(0.0);\n\
+         vec2[4] parents = getParents(vsoTexCoord.st);\n\
+         for(int i = 0; i < 4; i++) {\n\
+           if(parents[i].x != 65535) {\n\
+             vec2 p = vec2(parents[i].x / width , parents[i].y / height);\n\
+             w = 1.0 - length(p - vsoTexCoord) / maxdist;\n\
+             v += w * (vec4(1.0) - I_sign * (vec4(1.0) - pow(vec4(w), I_abs))) * texture(etage0, p);\n\
+             sumw += w;\n\
+           }\n\
+         }\n\
+         if(sumw > 0.0)\n\
+           v /= sumw;\n\
+         v += pow(vec4(2.0), vec4(-(myLevel + 1) * mcmd_noise_H)) * (mcmd_noise_S * (mcmd_noise_T + rand(vsoTexCoord.st + vec2(seed), mcmd_noise_phase_change)));\n\
+         fragColor = max(v, minc);\n\
+       } else\n\
          fragColor = texture(etage0, vsoTexCoord.st);\n			\
      }";
 
 static const char * gl4dfMCMD_mdLocalFS =
   "<imfs>gl4dfMCMD_mdLocal.fs</imfs>\n\
-     #version 330\n							\
-     in vec2 vsoTexCoord;\n						\
-     out vec4 fragColor;\n						\
-     uniform int width, height, level, maxLevel, use_etage3, use_etage4, use_etage5, use_etage6;\n \
-     uniform sampler2D etage0, etage1, etage2, etage3, etage4, etage5, etage6;\n \
-     uniform float seed, local_Hf;\n					\
-     uniform vec4 mcmd_noise_H, mcmd_noise_S, mcmd_noise_T, mcmd_noise_phase_change, mcmd_I;\n \
-     vec2[4] getParents(vec2 st) {\n					\
-       int i, x;\n							\
-       vec2 p[4];\n							\
-       vec4 c;\n							\
-       for(i = 0; i < 4; i++) {\n					\
-         x = i + int((st.s * float(width) - 0.5 /*transforme le nearest en floor*/) * 4.0);\n \
-         c = texture(etage1, vec2(float(x) / (float(width) * 4.0), st.t));\n \
-         p[i].x = (int(c.r * 255.0) << 8) | int(c.g * 255.0);\n		\
-         p[i].y = (int(c.b * 255.0) << 8) | int(c.a * 255.0);\n		\
-       }\n								\
-       return p;\n							\
-     }\n								\
-     highp float rand(vec2 co) {\n					\
-       highp float a = 12.9898;\n					\
-       highp float b = 78.233;\n					\
-       highp float c = 43758.5453;\n					\
-       highp float dt= dot(co.xy ,vec2(a,b));\n				\
-       highp float sn= mod(dt,3.14);\n					\
-       return 2.0 * fract(sin(sn) * c) - 1.0;\n				\
-     }\n								\
-     highp vec4 rand(vec2 co, vec4 s) {\n				\
-       return vec4(rand(co + vec2(s.x)), rand(co + vec2(s.y)), rand(co + vec2(s.z)), rand(co + vec2(s.w)));\n \
-     }\n								\
-     void main() {\n							\
-       const vec4 minc = vec4(1.0 / 255.0);\n				\
-       int myLevel = int(texture(etage2, vsoTexCoord.st).r * 255.0);\n	\
-       if(myLevel == level && texture(etage0, vsoTexCoord.st).r == 0.0) {\n \
-         const float maxdist = sqrt(2.0) / 2.0;\n				\
-         vec4 texH  = mcmd_noise_H + (use_etage3 != 0 ? local_Hf * (texture(etage3, vsoTexCoord.st) - vec4(0.5)) : vec4(0));\n \
-         vec4 texI  = mcmd_I + (use_etage4 != 0 ? 10.0 * (texture(etage4, vsoTexCoord.st) - vec4(0.5)) : vec4(0));\n \
-         vec4 texNS  = max(mcmd_noise_S + (use_etage5 != 0 ? 10.0 * (texture(etage5, vsoTexCoord.st) - vec4(0.5)) : vec4(0)), vec4(0));\n \
-         vec4 texNT  = mcmd_noise_T + (use_etage6 != 0 ? 10.0 * (texture(etage6, vsoTexCoord.st) - vec4(0.5)) : vec4(0));\n \
-         float sumw = 0.0, w;\n						\
-         vec4 I_sign = vec4(texI.x < 0.0 ? -1.0 : 1.0, texI.y < 0.0 ? -1.0 : 1.0, texI.z < 0.0 ? -1.0 : 1.0, texI.w < 0.0 ? -1.0 : 1.0);\n \
-         vec4 I_abs = abs(texI), v = vec4(0.0);\n			\
-         vec2[4] parents = getParents(vsoTexCoord.st);\n		\
-         for(int i = 0; i < 4; i++) {\n					\
-           if(parents[i].x != 65535) {\n				\
-             vec2 p = vec2(parents[i].x / width , parents[i].y / height);\n \
-             w = 1.0 - length(p - vsoTexCoord) / maxdist;\n		\
-             v += w * (vec4(1.0) - I_sign * (vec4(1.0) - pow(vec4(w), I_abs))) * texture(etage0, p);\n \
-             sumw += w;\n						\
-           }\n								\
-         }\n								\
-         if(sumw > 0.0)\n						\
-           v /= sumw;\n							\
-         v += pow(vec4(2.0), vec4(-(myLevel + 1) * texH)) * (texNS * (texNT + rand(vsoTexCoord.st + vec2(seed), mcmd_noise_phase_change)));\n \
-         fragColor = max(v, minc);\n					\
-       } else\n								\
-         fragColor = texture(etage0, vsoTexCoord.st);\n			\
+     #version 330\n\
+     in vec2 vsoTexCoord;\n\
+     out vec4 fragColor;\n\
+     uniform int width, height, level, maxLevel, use_etage3, use_etage4, use_etage5, use_etage6;\n\
+     uniform sampler2D etage0, etage1, etage2, etage3, etage4, etage5, etage6;\n\
+     uniform float seed, local_Hf;\n\
+     uniform vec4 mcmd_noise_H, mcmd_noise_S, mcmd_noise_T, mcmd_noise_phase_change, mcmd_I;\n\
+     vec2[4] getParents(vec2 st) {\n\
+       int i, x;\n\
+       vec2 p[4];\n\
+       vec4 c;\n\
+       for(i = 0; i < 4; i++) {\n\
+         x = i + int((st.s * float(width) - 0.5 /*transforme le nearest en floor*/) * 4.0);\n\
+         c = texture(etage1, vec2(float(x) / (float(width) * 4.0), st.t));\n\
+         p[i].x = (int(c.r * 255.0) << 8) | int(c.g * 255.0);\n\
+         p[i].y = (int(c.b * 255.0) << 8) | int(c.a * 255.0);\n\
+       }\n\
+       return p;\n\
+     }\n\
+     highp float rand(vec2 co) {\n\
+       highp float a = 12.9898;\n\
+       highp float b = 78.233;\n\
+       highp float c = 43758.5453;\n\
+       highp float dt= dot(co.xy ,vec2(a,b));\n\
+       highp float sn= mod(dt,3.14);\n\
+       return 2.0 * fract(sin(sn) * c) - 1.0;\n\
+     }\n\
+     highp vec4 rand(vec2 co, vec4 s) {\n\
+       return vec4(rand(co + vec2(s.x)), rand(co + vec2(s.y)), rand(co + vec2(s.z)), rand(co + vec2(s.w)));\n\
+     }\n\
+     void main() {\n\
+       const vec4 minc = vec4(1.0 / 255.0);\n\
+       int myLevel = int(texture(etage2, vsoTexCoord.st).r * 255.0);\n\
+       if(myLevel == level && texture(etage0, vsoTexCoord.st).r == 0.0) {\n\
+         const float maxdist = sqrt(2.0) / 2.0;\n\
+         vec4 texH  = mcmd_noise_H + (use_etage3 != 0 ? local_Hf * (texture(etage3, vsoTexCoord.st) - vec4(0.5)) : vec4(0));\n\
+         vec4 texI  = mcmd_I + (use_etage4 != 0 ? 10.0 * (texture(etage4, vsoTexCoord.st) - vec4(0.5)) : vec4(0));\n\
+         vec4 texNS  = max(mcmd_noise_S + (use_etage5 != 0 ? 10.0 * (texture(etage5, vsoTexCoord.st) - vec4(0.5)) : vec4(0)), vec4(0));\n\
+         vec4 texNT  = mcmd_noise_T + (use_etage6 != 0 ? 10.0 * (texture(etage6, vsoTexCoord.st) - vec4(0.5)) : vec4(0));\n\
+         float sumw = 0.0, w;\n\
+         vec4 I_sign = vec4(texI.x < 0.0 ? -1.0 : 1.0, texI.y < 0.0 ? -1.0 : 1.0, texI.z < 0.0 ? -1.0 : 1.0, texI.w < 0.0 ? -1.0 : 1.0);\n\
+         vec4 I_abs = abs(texI), v = vec4(0.0);\n\
+         vec2[4] parents = getParents(vsoTexCoord.st);\n\
+         for(int i = 0; i < 4; i++) {\n\
+           if(parents[i].x != 65535) {\n\
+             vec2 p = vec2(parents[i].x / width , parents[i].y / height);\n\
+             w = 1.0 - length(p - vsoTexCoord) / maxdist;\n\
+             v += w * (vec4(1.0) - I_sign * (vec4(1.0) - pow(vec4(w), I_abs))) * texture(etage0, p);\n\
+             sumw += w;\n\
+           }\n\
+         }\n\
+         if(sumw > 0.0)\n\
+           v /= sumw;\n\
+         v += pow(vec4(2.0), vec4(-(myLevel + 1) * texH)) * (texNS * (texNT + rand(vsoTexCoord.st + vec2(seed), mcmd_noise_phase_change)));\n\
+         fragColor = max(v, minc);\n\
+       } else\n\
+         fragColor = texture(etage0, vsoTexCoord.st);\n\
      }";
 
 static const char * gl4dfMCMD_mdbuV0FS =
   "<imfs>gl4dfMCMD_mdbuV0.fs</imfs>\n\
-     #version 330\n							\
-     in vec2 vsoTexCoord;\n						\
-     out vec4 fragColor;\n						\
-     uniform vec4 mcmd_Ir;\n						\
-     uniform int width, mcmd_take_color, buTreeSize, buTreeWidth, buTreeHeight;\n \
-     uniform sampler2D etage0, etage1, etage2, etage3;\n		\
-     float luminance(vec3 rgb) {\n					\
-       return dot(vec3(0.299, 0.587, 0.114), rgb);\n			\
-     }\n								\
-     uint rgba2ui(vec4 rgba) {\n					\
-       return (uint(rgba.r * 255.0) << uint(24)) |\n			\
-         (uint(rgba.g * 255.0) << uint(16)) |\n				\
-         (uint(rgba.b * 255.0) << uint(8) ) |\n				\
-         (uint(rgba.a * 255.0));\n					\
-     }\n								\
-     float rgba2f(vec4 rgba) {\n					\
-       return float(rgba2ui(rgba)) / float(uint(-1));\n			\
-     }\n								\
-     vec2 getChild(uint ipos) {\n					\
-       return vec2(float(ipos % uint(buTreeWidth)) / float(buTreeWidth - 1.0), float(ipos / uint(buTreeWidth)) / float(buTreeHeight - 1.0));\n \
-     }\n								\
-     vec2 readChildCoords(uint pos, float step) {\n			\
-       return vec2(texture(etage2, getChild(pos)).r, texture(etage2, getChild(pos + uint(1))).r) * step;\n \
-     }\n								\
-     void main() {\n							\
-       vec4 coul = texture(etage0, vsoTexCoord.st);\n			\
-       if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n	\
-         fragColor = coul;\n						\
-         return;\n							\
-       }\n								\
-       float step = 65535.0 / float(width - 1.0);\n			\
-       uint i0 = rgba2ui(texture(etage1, vsoTexCoord.st));\n		\
-       if(mcmd_take_color != 0) {\n					\
-         uint i0 = rgba2ui(texture(etage1, vsoTexCoord.st));\n		\
-         for(vec2 ret; (ret = readChildCoords(i0, step)).x <= 1.0; i0 += uint(2)) {\n \
-           if(ret.x >= 0.0 && ret.x <= 1.0 && ret.y >= 0.0 && ret.y <= 1.0) {\n	\
-             coul = texture(etage0, ret);\n				\
-           if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n	\
-               fragColor = texture(etage3, vsoTexCoord.st);\n		\
-               return;\n						\
-             }\n							\
-           }\n								\
-         }\n								\
-         fragColor = vec4(0.0, 0.0, 0.0, 1.0);\n			\
-       } else {\n							\
-         const float maxdist = sqrt(2.0) / 2.0;\n				\
-         float sumn = 0.0, w;\n						\
-         vec4 Ir_sign = vec4(mcmd_Ir.x < 0.0 ? -1.0 : 1.0, mcmd_Ir.y < 0.0 ? -1.0 : 1.0, mcmd_Ir.z < 0.0 ? -1.0 : 1.0, mcmd_Ir.w < 0.0 ? -1.0 : 1.0);\n	\
-         vec4 sumcoul = vec4(0.0), Ir_abs = abs(mcmd_Ir);\n		\
-         for(vec2 ret; (ret = readChildCoords(i0, step)).x <= 1.0; i0 += uint(2)) {\n \
-           if(ret.x >= 0.0 && ret.x <= 1.0 && ret.y >= 0.0 && ret.y <= 1.0) {\n	\
-             coul = texture(etage0, ret);\n				\
-             if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n	\
-               w = 1.0 - length(ret - vsoTexCoord) / maxdist;\n		\
+     #version 330\n\
+     in vec2 vsoTexCoord;\n\
+     out vec4 fragColor;\n\
+     uniform vec4 mcmd_Ir;\n\
+     uniform int width, mcmd_take_color, buTreeSize, buTreeWidth, buTreeHeight;\n\
+     uniform sampler2D etage0, etage1, etage2, etage3;\n\
+     float luminance(vec3 rgb) {\n\
+       return dot(vec3(0.299, 0.587, 0.114), rgb);\n\
+     }\n\
+     uint rgba2ui(vec4 rgba) {\n\
+       return (uint(rgba.r * 255.0) << uint(24)) |\n\
+         (uint(rgba.g * 255.0) << uint(16)) |\n\
+         (uint(rgba.b * 255.0) << uint(8) ) |\n\
+         (uint(rgba.a * 255.0));\n\
+     }\n\
+     float rgba2f(vec4 rgba) {\n\
+       return float(rgba2ui(rgba)) / float(uint(-1));\n\
+     }\n\
+     vec2 getChild(uint ipos) {\n\
+       return vec2(float(ipos % uint(buTreeWidth)) / float(buTreeWidth - 1.0), float(ipos / uint(buTreeWidth)) / float(buTreeHeight - 1.0));\n\
+     }\n\
+     vec2 readChildCoords(uint pos, float step) {\n\
+       return vec2(texture(etage2, getChild(pos)).r, texture(etage2, getChild(pos + uint(1))).r) * step;\n\
+     }\n\
+     void main() {\n\
+       vec4 coul = texture(etage0, vsoTexCoord.st);\n\
+       if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n\
+         fragColor = coul;\n\
+         return;\n\
+       }\n\
+       float step = 65535.0 / float(width - 1.0);\n\
+       uint i0 = rgba2ui(texture(etage1, vsoTexCoord.st));\n\
+       if(mcmd_take_color != 0) {\n\
+         uint i0 = rgba2ui(texture(etage1, vsoTexCoord.st));\n\
+         for(vec2 ret; (ret = readChildCoords(i0, step)).x <= 1.0; i0 += uint(2)) {\n\
+           if(ret.x >= 0.0 && ret.x <= 1.0 && ret.y >= 0.0 && ret.y <= 1.0) {\n\
+             coul = texture(etage0, ret);\n\
+           if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n\
+               fragColor = texture(etage3, vsoTexCoord.st);\n\
+               return;\n\
+             }\n\
+           }\n\
+         }\n\
+         fragColor = vec4(0.0, 0.0, 0.0, 1.0);\n\
+       } else {\n\
+         const float maxdist = sqrt(2.0) / 2.0;\n\
+         float sumn = 0.0, w;\n\
+         vec4 Ir_sign = vec4(mcmd_Ir.x < 0.0 ? -1.0 : 1.0, mcmd_Ir.y < 0.0 ? -1.0 : 1.0, mcmd_Ir.z < 0.0 ? -1.0 : 1.0, mcmd_Ir.w < 0.0 ? -1.0 : 1.0);\n\
+         vec4 sumcoul = vec4(0.0), Ir_abs = abs(mcmd_Ir);\n\
+         for(vec2 ret; (ret = readChildCoords(i0, step)).x <= 1.0; i0 += uint(2)) {\n\
+           if(ret.x >= 0.0 && ret.x <= 1.0 && ret.y >= 0.0 && ret.y <= 1.0) {\n\
+             coul = texture(etage0, ret);\n\
+             if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n\
+               w = 1.0 - length(ret - vsoTexCoord) / maxdist;\n\
                sumcoul += w * (vec4(1.0) - Ir_sign * (vec4(1.0) - pow(vec4(w), Ir_abs))) * coul; \
-               sumn += w;\n						\
-             }\n							\
-           }\n								\
-         }\n								\
-         if(sumn > 0.0)\n						\
-           fragColor = sumcoul / sumn;\n				\
-         else\n								\
-           fragColor = vec4(0.0, 0.0, 0.0, 1.0);\n			\
-       }\n								\
+               sumn += w;\n\
+             }\n\
+           }\n\
+         }\n\
+         if(sumn > 0.0)\n\
+           fragColor = sumcoul / sumn;\n\
+         else\n\
+           fragColor = vec4(0.0, 0.0, 0.0, 1.0);\n\
+       }\n\
      }";
 
 static const char * gl4dfMCMD_mdbuV1FS/* New */ =
   "<imfs>gl4dfMCMD_mdbuV1.fs</imfs>\n\
-     #version 330\n							\
-     in vec2 vsoTexCoord;\n						\
-     out vec4 fragColor;\n						\
-     uniform vec4 mcmd_Ir;\n						\
-     uniform int width, mcmd_take_color, buTreeSize, buTreeWidth, buTreeHeight, use_etage4;\n \
-     uniform sampler2D etage0, etage1, etage2, etage3, etage4;\n	\
-     float luminance(vec3 rgb) {\n					\
-       return dot(vec3(0.299, 0.587, 0.114), rgb);\n			\
-     }\n								\
-     uint rgba2ui(vec4 rgba) {\n					\
-       return (uint(rgba.r * 255.0) << uint(24)) |\n			\
-         (uint(rgba.g * 255.0) << uint(16)) |\n				\
-         (uint(rgba.b * 255.0) << uint(8) ) |\n				\
-         (uint(rgba.a * 255.0));\n					\
-     }\n								\
-     float rgba2f(vec4 rgba) {\n					\
-       return float(rgba2ui(rgba)) / float(uint(-1));\n			\
-     }\n								\
-     vec2 getChild(uint ipos) {\n					\
-       return vec2(float(ipos % uint(buTreeWidth)) / float(buTreeWidth - 1.0), float(ipos / uint(buTreeWidth)) / float(buTreeHeight - 1.0));\n \
-     }\n								\
-     vec2 readChildCoords(uint pos, float step) {\n			\
-       return vec2(texture(etage2, getChild(pos)).r, texture(etage2, getChild(pos + uint(1))).r) * step;\n \
-     }\n								\
-     void main() {\n							\
-       vec4 coul = texture(etage0, vsoTexCoord.st);\n			\
-       float orig_a = coul.a;\n						\
-       if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n	\
-         fragColor = coul;\n						\
-         return;\n							\
-       }\n								\
-       float step = 65535.0 / float(width - 1.0);\n			\
-       uint i0 = rgba2ui(texture(etage1, vsoTexCoord.st));\n		\
-       if(mcmd_take_color != 0) {\n					\
-         uint i0 = rgba2ui(texture(etage1, vsoTexCoord.st));\n		\
-         for(vec2 ret; (ret = readChildCoords(i0, step)).x <= 1.0; i0 += uint(2)) {\n \
-           if(ret.x >= 0.0 && ret.x <= 1.0 && ret.y >= 0.0 && ret.y <= 1.0) {\n	\
-             coul = texture(etage0, ret);\n				\
-           if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n	\
-               fragColor = texture(etage3, vsoTexCoord.st);\n		\
-               return;\n						\
-             }\n							\
-           }\n								\
-         }\n								\
-         fragColor = vec4(0.0, 0.0, 0.0, orig_a /* avant 1.0 */);\n	\
-       } else {\n							\
-         int nw = 0;\n							\
-         const float maxdist = sqrt(2.0) / 2.0;\n			\
-         float sumn = 0.0, suma = 0.0, w, d, sc = 0.03125, sf = 0.9;\n	\
-         vec4 texIr = mcmd_Ir + (use_etage4 != 0 ? 10.0 * (texture(etage4, vsoTexCoord.st) - vec4(0.5)) : vec4(0));\n \
-         vec4 Ir_sign = vec4(texIr.x < 0.0 ? -1.0 : 1.0, texIr.y < 0.0 ? -1.0 : 1.0, texIr.z < 0.0 ? -1.0 : 1.0, texIr.w < 0.0 ? -1.0 : 1.0);\n	\
-         vec4 sumcoul = vec4(0.0), Ir_abs = abs(texIr);\n		\
-         for(vec2 ret; (ret = readChildCoords(i0, step)).x <= 1.0; i0 += uint(2)) {\n \
-           if(ret.x >= 0.0 && ret.x <= 1.0 && ret.y >= 0.0 && ret.y <= 1.0) {\n	\
-             coul = texture(etage0, ret);\n				\
-             if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n	\
-               float ridge_river_fact = 1.0;\n				\
-               if(coul.a < 1.0 && coul.a > 0.0) { \n			\
-                 ridge_river_fact = -1.0;\n				\
-               }\n							\
-               d = (length(ret - vsoTexCoord) / maxdist);\n		\
-               //sf=0.1;sc=0.032; plot (x<sc) ? x : sc+(1-sc)*((x-sc)**sf) / ((1-sc)**sf);\n \
-               if(d > sc) \n						\
-                 //d = sc + (1.0 - sc) * pow(d - sc, sf) / pow(1.0 - sc, sf);\n \
-                 d = min(pow(d, sf) + (d - sc) * pow((d - sc) / (1.0 - sc), 1.0/sf), 10.0); //sc + (1.0 - sc) * pow(d - sc, sf) / pow(1.0 - sc, sf);\n \
-               else\n							\
-                 d = pow(d, sf);\n					\
-               w = 1.0 - d;\n						\
+     #version 330\n\
+     in vec2 vsoTexCoord;\n\
+     out vec4 fragColor;\n\
+     uniform vec4 mcmd_Ir;\n\
+     uniform int width, mcmd_take_color, buTreeSize, buTreeWidth, buTreeHeight, use_etage4;\n\
+     uniform sampler2D etage0, etage1, etage2, etage3, etage4;\n\
+     float luminance(vec3 rgb) {\n\
+       return dot(vec3(0.299, 0.587, 0.114), rgb);\n\
+     }\n\
+     uint rgba2ui(vec4 rgba) {\n\
+       return (uint(rgba.r * 255.0) << uint(24)) |\n\
+         (uint(rgba.g * 255.0) << uint(16)) |\n\
+         (uint(rgba.b * 255.0) << uint(8) ) |\n\
+         (uint(rgba.a * 255.0));\n\
+     }\n\
+     float rgba2f(vec4 rgba) {\n\
+       return float(rgba2ui(rgba)) / float(uint(-1));\n\
+     }\n\
+     vec2 getChild(uint ipos) {\n\
+       return vec2(float(ipos % uint(buTreeWidth)) / float(buTreeWidth - 1.0), float(ipos / uint(buTreeWidth)) / float(buTreeHeight - 1.0));\n\
+     }\n\
+     vec2 readChildCoords(uint pos, float step) {\n\
+       return vec2(texture(etage2, getChild(pos)).r, texture(etage2, getChild(pos + uint(1))).r) * step;\n\
+     }\n\
+     void main() {\n\
+       vec4 coul = texture(etage0, vsoTexCoord.st);\n\
+       float orig_a = coul.a;\n\
+       if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n\
+         fragColor = coul;\n\
+         return;\n\
+       }\n\
+       float step = 65535.0 / float(width - 1.0);\n\
+       uint i0 = rgba2ui(texture(etage1, vsoTexCoord.st));\n\
+       if(mcmd_take_color != 0) {\n\
+         uint i0 = rgba2ui(texture(etage1, vsoTexCoord.st));\n\
+         for(vec2 ret; (ret = readChildCoords(i0, step)).x <= 1.0; i0 += uint(2)) {\n\
+           if(ret.x >= 0.0 && ret.x <= 1.0 && ret.y >= 0.0 && ret.y <= 1.0) {\n\
+             coul = texture(etage0, ret);\n\
+           if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n\
+               fragColor = texture(etage3, vsoTexCoord.st);\n\
+               return;\n\
+             }\n\
+           }\n\
+         }\n\
+         fragColor = vec4(0.0, 0.0, 0.0, orig_a /* avant 1.0 */);\n\
+       } else {\n\
+         int nw = 0;\n\
+         const float maxdist = sqrt(2.0) / 2.0;\n\
+         float sumn = 0.0, suma = 0.0, w, d, sc = 0.03125, sf = 0.9;\n\
+         vec4 texIr = mcmd_Ir + (use_etage4 != 0 ? 10.0 * (texture(etage4, vsoTexCoord.st) - vec4(0.5)) : vec4(0));\n\
+         vec4 Ir_sign = vec4(texIr.x < 0.0 ? -1.0 : 1.0, texIr.y < 0.0 ? -1.0 : 1.0, texIr.z < 0.0 ? -1.0 : 1.0, texIr.w < 0.0 ? -1.0 : 1.0);\n\
+         vec4 sumcoul = vec4(0.0), Ir_abs = abs(texIr);\n\
+         for(vec2 ret; (ret = readChildCoords(i0, step)).x <= 1.0; i0 += uint(2)) {\n\
+           if(ret.x >= 0.0 && ret.x <= 1.0 && ret.y >= 0.0 && ret.y <= 1.0) {\n\
+             coul = texture(etage0, ret);\n\
+             if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n\
+               float ridge_river_fact = 1.0;\n\
+               if(coul.a < 1.0 && coul.a > 0.0) { \n\
+                 ridge_river_fact = -1.0;\n\
+               }\n\
+               d = (length(ret - vsoTexCoord) / maxdist);\n\
+               //sf=0.1;sc=0.032; plot (x<sc) ? x : sc+(1-sc)*((x-sc)**sf) / ((1-sc)**sf);\n\
+               if(d > sc) \n\
+                 //d = sc + (1.0 - sc) * pow(d - sc, sf) / pow(1.0 - sc, sf);\n\
+                 d = min(pow(d, sf) + (d - sc) * pow((d - sc) / (1.0 - sc), 1.0/sf), 10.0); //sc + (1.0 - sc) * pow(d - sc, sf) / pow(1.0 - sc, sf);\n\
+               else\n\
+                 d = pow(d, sf);\n\
+               w = 1.0 - d;\n\
                sumcoul += w * (vec4(1.0) - ridge_river_fact * Ir_sign * (vec4(1.0) - pow(vec4(w), Ir_abs))) * coul; \
-               suma += w * ridge_river_fact;\n				\
-               sumn += w; ++nw;\n						\
-             }\n							\
-           }\n								\
-         }\n								\
-         if((nw == 1 && sumn >= 1.0 - sc) || sumn >= 2.0 - 2.0 * sc)\n	\
-           fragColor = vec4(sumcoul.rgb / sumn, suma < 0.0 ? 254.0 / 255.0 : 1.0);\n \
-         else\n								\
-           fragColor = vec4(0.0, 0.0, 0.0, orig_a/* avant 0.0 */);\n	\
-       }\n								\
+               suma += w * ridge_river_fact;\n\
+               sumn += w; ++nw;\n\
+             }\n\
+           }\n\
+         }\n\
+         if((nw == 1 && sumn >= 1.0 - sc) || sumn >= 2.0 - 2.0 * sc)\n\
+           fragColor = vec4(sumcoul.rgb / sumn, suma < 0.0 ? 254.0 / 255.0 : 1.0);\n\
+         else\n\
+           fragColor = vec4(0.0, 0.0, 0.0, orig_a/* avant 0.0 */);\n\
+       }\n\
      }";
 
 static const char * gl4dfMCMD_mdbuV1FSOld =
   "<imfs>gl4dfMCMD_mdbuV1.fs</imfs>\n\
-     #version 330\n							\
-     in vec2 vsoTexCoord;\n						\
-     out vec4 fragColor;\n						\
-     uniform vec4 mcmd_Ir;\n						\
-     uniform int width, mcmd_take_color, buTreeSize, buTreeWidth, buTreeHeight, use_etage4;\n \
-     uniform sampler2D etage0, etage1, etage2, etage3, etage4;\n	\
-     float luminance(vec3 rgb) {\n					\
-       return dot(vec3(0.299, 0.587, 0.114), rgb);\n			\
-     }\n								\
-     uint rgba2ui(vec4 rgba) {\n					\
-       return (uint(rgba.r * 255.0) << uint(24)) |\n			\
-         (uint(rgba.g * 255.0) << uint(16)) |\n				\
-         (uint(rgba.b * 255.0) << uint(8) ) |\n				\
-         (uint(rgba.a * 255.0));\n					\
-     }\n								\
-     float rgba2f(vec4 rgba) {\n					\
-       return float(rgba2ui(rgba)) / float(uint(-1));\n			\
-     }\n								\
-     vec2 getChild(uint ipos) {\n					\
-       return vec2(float(ipos % uint(buTreeWidth)) / float(buTreeWidth - 1.0), float(ipos / uint(buTreeWidth)) / float(buTreeHeight - 1.0));\n \
-     }\n								\
-     vec2 readChildCoords(uint pos, float step) {\n			\
-       return vec2(texture(etage2, getChild(pos)).r, texture(etage2, getChild(pos + uint(1))).r) * step;\n \
-     }\n								\
-     void main() {\n							\
-       vec4 coul = texture(etage0, vsoTexCoord.st);\n			\
-       if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n	\
-         fragColor = coul;\n						\
-         return;\n							\
-       }\n								\
-       float step = 65535.0 / float(width - 1.0);\n			\
-       uint i0 = rgba2ui(texture(etage1, vsoTexCoord.st));\n		\
-       if(mcmd_take_color != 0) {\n					\
-         uint i0 = rgba2ui(texture(etage1, vsoTexCoord.st));\n		\
-         for(vec2 ret; (ret = readChildCoords(i0, step)).x <= 1.0; i0 += uint(2)) {\n \
-           if(ret.x >= 0.0 && ret.x <= 1.0 && ret.y >= 0.0 && ret.y <= 1.0) {\n	\
-             coul = texture(etage0, ret);\n				\
-           if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n	\
-               fragColor = texture(etage3, vsoTexCoord.st);\n		\
-               return;\n						\
-             }\n							\
-           }\n								\
-         }\n								\
-         fragColor = vec4(0.0, 0.0, 0.0, 1.0);\n			\
-       } else {\n							\
-         const float maxdist = sqrt(2.0) / 2.0;\n			\
-         float sumn = 0.0, w, d, sc = 0.032, sf = 0.01;\n		\
-         vec4 texIr = mcmd_Ir + (use_etage4 != 0 ? 10.0 * (texture(etage4, vsoTexCoord.st) - vec4(0.5)) : vec4(0));\n \
-         vec4 Ir_sign = vec4(texIr.x < 0.0 ? -1.0 : 1.0, texIr.y < 0.0 ? -1.0 : 1.0, texIr.z < 0.0 ? -1.0 : 1.0, texIr.w < 0.0 ? -1.0 : 1.0);\n	\
-         vec4 sumcoul = vec4(0.0), Ir_abs = abs(texIr);\n		\
-         for(vec2 ret; (ret = readChildCoords(i0, step)).x <= 1.0; i0 += uint(2)) {\n \
-           if(ret.x >= 0.0 && ret.x <= 1.0 && ret.y >= 0.0 && ret.y <= 1.0) {\n	\
-             coul = texture(etage0, ret);\n				\
-             if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n	\
-               d = (length(ret - vsoTexCoord) / maxdist);\n		\
-               //sf=0.1;sc=0.032; plot (x<sc) ? x : sc+(1-sc)*((x-sc)**sf) / ((1-sc)**sf);\n \
-               if(d > sc) \n						\
-                 d = sc + (1.0 - sc) * pow(d - sc, sf) / pow(1.0 - sc, sf);\n \
-               w = 1.0 - d;\n						\
+     #version 330\n\
+     in vec2 vsoTexCoord;\n\
+     out vec4 fragColor;\n\
+     uniform vec4 mcmd_Ir;\n\
+     uniform int width, mcmd_take_color, buTreeSize, buTreeWidth, buTreeHeight, use_etage4;\n\
+     uniform sampler2D etage0, etage1, etage2, etage3, etage4;\n\
+     float luminance(vec3 rgb) {\n\
+       return dot(vec3(0.299, 0.587, 0.114), rgb);\n\
+     }\n\
+     uint rgba2ui(vec4 rgba) {\n\
+       return (uint(rgba.r * 255.0) << uint(24)) |\n\
+         (uint(rgba.g * 255.0) << uint(16)) |\n\
+         (uint(rgba.b * 255.0) << uint(8) ) |\n\
+         (uint(rgba.a * 255.0));\n\
+     }\n\
+     float rgba2f(vec4 rgba) {\n\
+       return float(rgba2ui(rgba)) / float(uint(-1));\n\
+     }\n\
+     vec2 getChild(uint ipos) {\n\
+       return vec2(float(ipos % uint(buTreeWidth)) / float(buTreeWidth - 1.0), float(ipos / uint(buTreeWidth)) / float(buTreeHeight - 1.0));\n\
+     }\n\
+     vec2 readChildCoords(uint pos, float step) {\n\
+       return vec2(texture(etage2, getChild(pos)).r, texture(etage2, getChild(pos + uint(1))).r) * step;\n\
+     }\n\
+     void main() {\n\
+       vec4 coul = texture(etage0, vsoTexCoord.st);\n\
+       if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n\
+         fragColor = coul;\n\
+         return;\n\
+       }\n\
+       float step = 65535.0 / float(width - 1.0);\n\
+       uint i0 = rgba2ui(texture(etage1, vsoTexCoord.st));\n\
+       if(mcmd_take_color != 0) {\n\
+         uint i0 = rgba2ui(texture(etage1, vsoTexCoord.st));\n\
+         for(vec2 ret; (ret = readChildCoords(i0, step)).x <= 1.0; i0 += uint(2)) {\n\
+           if(ret.x >= 0.0 && ret.x <= 1.0 && ret.y >= 0.0 && ret.y <= 1.0) {\n\
+             coul = texture(etage0, ret);\n\
+           if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n\
+               fragColor = texture(etage3, vsoTexCoord.st);\n\
+               return;\n\
+             }\n\
+           }\n\
+         }\n\
+         fragColor = vec4(0.0, 0.0, 0.0, 1.0);\n\
+       } else {\n\
+         const float maxdist = sqrt(2.0) / 2.0;\n\
+         float sumn = 0.0, w, d, sc = 0.032, sf = 0.01;\n\
+         vec4 texIr = mcmd_Ir + (use_etage4 != 0 ? 10.0 * (texture(etage4, vsoTexCoord.st) - vec4(0.5)) : vec4(0));\n\
+         vec4 Ir_sign = vec4(texIr.x < 0.0 ? -1.0 : 1.0, texIr.y < 0.0 ? -1.0 : 1.0, texIr.z < 0.0 ? -1.0 : 1.0, texIr.w < 0.0 ? -1.0 : 1.0);\n\
+         vec4 sumcoul = vec4(0.0), Ir_abs = abs(texIr);\n\
+         for(vec2 ret; (ret = readChildCoords(i0, step)).x <= 1.0; i0 += uint(2)) {\n\
+           if(ret.x >= 0.0 && ret.x <= 1.0 && ret.y >= 0.0 && ret.y <= 1.0) {\n\
+             coul = texture(etage0, ret);\n\
+             if(!(coul.r == 0.0 && coul.g == 0.0 && coul.b == 0.0)) {\n\
+               d = (length(ret - vsoTexCoord) / maxdist);\n\
+               //sf=0.1;sc=0.032; plot (x<sc) ? x : sc+(1-sc)*((x-sc)**sf) / ((1-sc)**sf);\n\
+               if(d > sc) \n\
+                 d = sc + (1.0 - sc) * pow(d - sc, sf) / pow(1.0 - sc, sf);\n\
+               w = 1.0 - d;\n\
                sumcoul += w * (vec4(1.0) - Ir_sign * (vec4(1.0) - pow(vec4(w), Ir_abs))) * coul; \
-               sumn += w;\n						\
-             }\n							\
-           }\n								\
-         }\n								\
-         if(sumn >= 1.0 - sc)\n						\
-           fragColor = sumcoul / sumn;\n				\
-         else\n								\
-           fragColor = vec4(0.0, 0.0, 0.0, 0.0);\n			\
-       }\n								\
+               sumn += w;\n\
+             }\n\
+           }\n\
+         }\n\
+         if(sumn >= 1.0 - sc)\n\
+           fragColor = sumcoul / sumn;\n\
+         else\n\
+           fragColor = vec4(0.0, 0.0, 0.0, 0.0);\n\
+       }\n\
      }";
 
 static void init(void) {

--- a/lib_src/GL4D/gl4dfMedian.c
+++ b/lib_src/GL4D/gl4dfMedian.c
@@ -5,7 +5,7 @@
  *
  * \author Farès BELHADJ amsi@ai.univ-paris8.fr
  * \date March 08, 2017
- * 
+ *
  */
 
 #include "gl4du.h"
@@ -33,7 +33,8 @@ static void medianfinit(GLuint in, GLuint out, GLuint nb_iterations, GLboolean f
 /* appelée les autres fois (après la première qui lance init) */
 static void medianffunc(GLuint in, GLuint out, GLuint nb_iterations, GLboolean flipV) {
   GLuint rout = out, fbo, flipflop[2];
-  GLint i, n, vp[4], w, h, cfbo, ctex, cpId;
+  GLint vp[4], w, h, cfbo, ctex, cpId;
+  GLuint i;
   GLboolean dt = glIsEnabled(GL_DEPTH_TEST), bl = glIsEnabled(GL_BLEND);
 #ifndef __GLES4D__
   GLint polygonMode[2];
@@ -51,7 +52,7 @@ static void medianffunc(GLuint in, GLuint out, GLuint nb_iterations, GLboolean f
     gl4dfConvTex2Tex(out, _tempTexId[0], GL_FALSE);
   }
   if(out == 0) { /* Pas de sortie, donc sortie aux dimensions du viewport */
-    w = vp[2];// - vp[0]; 
+    w = vp[2];// - vp[0];
     h = vp[3];// - vp[1];
     fcommMatchTex(rout = _tempTexId[1], out);
   } else {
@@ -102,7 +103,8 @@ static void medianffunc(GLuint in, GLuint out, GLuint nb_iterations, GLboolean f
 }
 
 static void init(void) {
-  GLint i, ctex;
+  GLint ctex;
+  GLuint i;
   glGetIntegerv(GL_TEXTURE_BINDING_2D, &ctex);
   if(!_tempTexId[0])
     glGenTextures((sizeof _tempTexId / sizeof *_tempTexId), _tempTexId);

--- a/lib_src/GL4D/gl4dfOp.c
+++ b/lib_src/GL4D/gl4dfOp.c
@@ -5,7 +5,7 @@
  *
  * \author Farès BELHADJ amsi@ai.univ-paris8.fr
  * \date March 14, 2018
- * 
+ *
  */
 #include <math.h>
 #include <stdio.h>
@@ -53,7 +53,7 @@ static void opffunc(GLuint in1, GLuint in2, GLuint out, GLboolean flipV) {
   glGetIntegerv(GL_CURRENT_PROGRAM, &cpId);
 
   /* vérifier toutes les dimensions */
-  if( out == 0 /* pas de sortie, donc la sortie est l'écran */ || 
+  if( out == 0 /* pas de sortie, donc la sortie est l'écran */ ||
       (out == in1 || out == in2) /* ou une des entrées est la même que la sortie*/ )
     fcommMatchTex(rout = _tempTexId[2], out);
   if(in1 == 0) { /* Pas d'entrée 1, donc l'entrée est le dernier draw */
@@ -67,7 +67,7 @@ static void opffunc(GLuint in1, GLuint in2, GLuint out, GLboolean flipV) {
 
   glBindTexture(GL_TEXTURE_2D, rout);
   glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
-  glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);    
+  glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
   if(!bl) glEnable(GL_BLEND);
   if(dt) glDisable(GL_DEPTH_TEST);
 #ifndef __GLES4D__
@@ -107,7 +107,8 @@ static void opffunc(GLuint in1, GLuint in2, GLuint out, GLboolean flipV) {
 }
 
 static void init(void) {
-  GLint ctex, i;
+  GLint ctex;
+  GLuint i;
   glGetIntegerv(GL_TEXTURE_BINDING_2D, &ctex);
   if(!_tempTexId[0])
     glGenTextures((sizeof _tempTexId / sizeof *_tempTexId), _tempTexId);

--- a/lib_src/GL4D/gl4dfScattering.c
+++ b/lib_src/GL4D/gl4dfScattering.c
@@ -5,7 +5,7 @@
  *
  * \author Farès BELHADJ amsi@ai.univ-paris8.fr
  * \date March 09, 2017
- * 
+ *
  */
 #include <stdlib.h>
 #include <assert.h>
@@ -53,9 +53,9 @@ static void scatteringffunc(GLuint in, GLuint out, GLuint radius, GLuint displac
   } else if(in == out) {
     fcommMatchTex(in = _tempTexId[0], out);
     gl4dfConvTex2Tex(out, _tempTexId[0], GL_FALSE);
-  } 
+  }
   if(out == 0) { /* Pas de sortie, donc sortie aux dimensions du viewport */
-    w = vp[2];// - vp[0]; 
+    w = vp[2];// - vp[0];
     h = vp[3];// - vp[1];
     fcommMatchTex(rout = _tempTexId[1], out);
   } else {
@@ -63,7 +63,7 @@ static void scatteringffunc(GLuint in, GLuint out, GLuint radius, GLuint displac
     glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
     glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
   }
-  if(w != _width || h != _height)
+  if((GLuint)w != _width || (GLuint)h != _height)
     setDimensions(w, h);
 #ifndef __GLES4D__
   glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
@@ -122,7 +122,8 @@ static void scatteringffunc(GLuint in, GLuint out, GLuint radius, GLuint displac
 }
 
 static void init(void) {
-  GLint vp[4], i, ctex;
+  GLint vp[4], ctex;
+  long unsigned int i;
   glGetIntegerv(GL_VIEWPORT, vp);
   glGetIntegerv(GL_TEXTURE_BINDING_2D, &ctex);
   if(!_tempTexId[0])
@@ -176,9 +177,9 @@ static void init(void) {
 }
 
 static void setDimensions(GLuint w, GLuint h) {
-  int i;
-  GLfloat * noise = NULL; 
-  _width  = w; 
+  unsigned int i;
+  GLfloat * noise = NULL;
+  _width  = w;
   _height = h;
   noise = malloc(2 * _width * _height * sizeof *noise);
   assert(noise);

--- a/lib_src/GL4D/gl4dfSobel.c
+++ b/lib_src/GL4D/gl4dfSobel.c
@@ -5,7 +5,7 @@
  *
  * \author Farès BELHADJ amsi@ai.univ-paris8.fr
  * \date April 14, 2016
- * 
+ *
  */
 #include <math.h>
 #include <stdio.h>
@@ -105,7 +105,7 @@ static void sobelffunc(GLuint in, GLuint out, GLboolean flipV) {
     gl4dfConvTex2Tex(out, _tempTexId[0], GL_FALSE);
   }
   if(out == 0) { /* Pas de sortie, donc sortie aux dimensions du viewport */
-    w = vp[2];// - vp[0]; 
+    w = vp[2];// - vp[0];
     h = vp[3];// - vp[1];
     fcommMatchTex(rout = _tempTexId[1], out);
   } else {
@@ -156,7 +156,8 @@ static void sobelffunc(GLuint in, GLuint out, GLboolean flipV) {
 }
 
 static void init(void) {
-  GLint i, ctex;
+  GLint ctex;
+  GLuint i;
   glGetIntegerv(GL_TEXTURE_BINDING_2D, &ctex);
   if(!_tempTexId[0])
     glGenTextures((sizeof _tempTexId / sizeof *_tempTexId), _tempTexId);

--- a/lib_src/GL4D/gl4dg.c
+++ b/lib_src/GL4D/gl4dg.c
@@ -205,9 +205,9 @@ GLuint gl4dgGenSpheref(GLuint slices, GLuint stacks) {
   glGenBuffers(2, s->buffers);
   glBindBuffer(GL_ARRAY_BUFFER, s->buffers[0]);
   glBufferData(GL_ARRAY_BUFFER, 5 * (slices + 1) * (stacks + 1) * sizeof *idata, idata, GL_STATIC_DRAW);
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (5 * sizeof *idata), (const void *)0);  
-  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (5 * sizeof *idata), (const void *)0);  
-  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (5 * sizeof *idata), (const void *)(3 * sizeof *idata));  
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (5 * sizeof *idata), (const void *)0);
+  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (5 * sizeof *idata), (const void *)0);
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (5 * sizeof *idata), (const void *)(3 * sizeof *idata));
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s->buffers[1]);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, s->index_row_count * s->index_nb_rows * sizeof *index, index, GL_STATIC_DRAW);
   free(idata);
@@ -243,9 +243,9 @@ GLuint gl4dgGenConef(GLuint slices, GLboolean base) {
   glGenBuffers(1, &(c->buffer));
   glBindBuffer(GL_ARRAY_BUFFER, c->buffer);
   glBufferData(GL_ARRAY_BUFFER, (16 * (slices + 1) + (base ? 8 : 0) * (slices + 2)) * sizeof *data, data, GL_STATIC_DRAW);
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)0);  
-  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(3 * sizeof *data));  
-  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(6 * sizeof *data));  
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)0);
+  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(3 * sizeof *data));
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(6 * sizeof *data));
   free(data);
   glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -269,9 +269,9 @@ GLuint gl4dgGenFanConef(GLuint slices, GLboolean base) {
   glGenBuffers(1, &(c->buffer));
   glBindBuffer(GL_ARRAY_BUFFER, c->buffer);
   glBufferData(GL_ARRAY_BUFFER, (base ? 16 : 8) * (slices + 1 + /* le sommet ou le centre de la base */ 1) * sizeof *data, data, GL_STATIC_DRAW);
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)0);  
-  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(3 * sizeof *data));  
-  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(6 * sizeof *data));  
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)0);
+  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(3 * sizeof *data));
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(6 * sizeof *data));
   free(data);
   glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -295,9 +295,9 @@ GLuint gl4dgGenCylinderf(GLuint slices, GLboolean base) {
   glGenBuffers(1, &(c->buffer));
   glBindBuffer(GL_ARRAY_BUFFER, c->buffer);
   glBufferData(GL_ARRAY_BUFFER, (16 * (slices + 1) + (base ? 16 : 0) * (slices + 2)) * sizeof *data, data, GL_STATIC_DRAW);
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)0);  
-  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(3 * sizeof *data));  
-  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(6 * sizeof *data));  
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)0);
+  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(3 * sizeof *data));
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(6 * sizeof *data));
   free(data);
   glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -321,9 +321,9 @@ GLuint gl4dgGenDiskf(GLuint slices) {
   glGenBuffers(1, &(c->buffer));
   glBindBuffer(GL_ARRAY_BUFFER, c->buffer);
   glBufferData(GL_ARRAY_BUFFER, 8 * (slices + 1 + /* le centre du disk */ 1) * sizeof *data, data, GL_STATIC_DRAW);
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)0);  
-  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(3 * sizeof *data));  
-  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(6 * sizeof *data));  
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)0);
+  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(3 * sizeof *data));
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *data), (const void *)(6 * sizeof *data));
   free(data);
   glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -350,9 +350,9 @@ GLuint gl4dgGenTorusf(GLuint slices, GLuint stacks, GLfloat radius) {
   glGenBuffers(2, s->buffers);
   glBindBuffer(GL_ARRAY_BUFFER, s->buffers[0]);
   glBufferData(GL_ARRAY_BUFFER, 8 * (slices + 1) * (stacks + 1) * sizeof *idata, idata, GL_STATIC_DRAW);
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *idata), (const void *)0);  
-  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *idata), (const void *)(3 * sizeof *idata));  
-  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *idata), (const void *)(6 * sizeof *idata));  
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *idata), (const void *)0);
+  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *idata), (const void *)(3 * sizeof *idata));
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *idata), (const void *)(6 * sizeof *idata));
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s->buffers[1]);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, s->index_row_count * s->index_nb_rows * sizeof *index, index, GL_STATIC_DRAW);
   free(idata);
@@ -386,9 +386,9 @@ GLuint gl4dgGenGrid2dFromHeightMapf(GLuint width, GLuint height, GLfloat * heigh
   glGenBuffers(2, s->buffers);
   glBindBuffer(GL_ARRAY_BUFFER, s->buffers[0]);
   glBufferData(GL_ARRAY_BUFFER, 8 * width * height * sizeof *idata, idata, GL_STATIC_DRAW);
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *idata), (const void *)0);  
-  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *idata), (const void *)(3 * sizeof *idata));  
-  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *idata), (const void *)(6 * sizeof *idata));  
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *idata), (const void *)0);
+  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *idata), (const void *)(3 * sizeof *idata));
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *idata), (const void *)(6 * sizeof *idata));
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s->buffers[1]);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, s->index_row_count * s->index_nb_rows * sizeof *index, index, GL_STATIC_DRAW);
   free(idata);
@@ -451,7 +451,7 @@ void gl4dgDraw(GLuint id) {
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 2 * (((gcylinder_t *)(_garray[id].geom))->slices + 1));
     if(((gcylinder_t *)(_garray[id].geom))->base) {
       glDrawArrays(GL_TRIANGLE_FAN, 2 * (((gcylinder_t *)(_garray[id].geom))->slices + 1), ((gcylinder_t *)(_garray[id].geom))->slices + 2);
-      glDrawArrays(GL_TRIANGLE_FAN, 2 * (((gcylinder_t *)(_garray[id].geom))->slices + 1) + ((gcylinder_t *)(_garray[id].geom))->slices + 2, 
+      glDrawArrays(GL_TRIANGLE_FAN, 2 * (((gcylinder_t *)(_garray[id].geom))->slices + 1) + ((gcylinder_t *)(_garray[id].geom))->slices + 2,
 		   ((gcylinder_t *)(_garray[id].geom))->slices + 2);
     }
     glBindVertexArray(0);
@@ -535,39 +535,39 @@ static GLuint genId(void) {
 static GLuint mkStaticf(geom_e type) {
   static GLfloat quad_data[] = {
     -1.0f, -1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
-     1.0f, -1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 
+     1.0f, -1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f,
     -1.0f,  1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f,
      1.0f,  1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f
   };
   static GLfloat cube_data[] = {
     /* front */
     -1.0f, -1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
-     1.0f, -1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 
+     1.0f, -1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f,
     -1.0f,  1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f,
      1.0f,  1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f,
     /* back */
      1.0f, -1.0f, -1.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f,
-    -1.0f, -1.0f, -1.0f, 0.0f, 0.0f, -1.0f, 1.0f, 0.0f, 
+    -1.0f, -1.0f, -1.0f, 0.0f, 0.0f, -1.0f, 1.0f, 0.0f,
      1.0f,  1.0f, -1.0f, 0.0f, 0.0f, -1.0f, 0.0f, 1.0f,
     -1.0f,  1.0f, -1.0f, 0.0f, 0.0f, -1.0f, 1.0f, 1.0f,
     /* right */
     1.0f, -1.0f,  1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-    1.0f, -1.0f, -1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 
+    1.0f, -1.0f, -1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 0.0f,
     1.0f,  1.0f,  1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f,
     1.0f,  1.0f, -1.0f, 1.0f, 0.0f, 0.0f, 1.0f, 1.0f,
     /* left */
     -1.0f, -1.0f, -1.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-    -1.0f, -1.0f,  1.0f, -1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 
+    -1.0f, -1.0f,  1.0f, -1.0f, 0.0f, 0.0f, 1.0f, 0.0f,
     -1.0f,  1.0f, -1.0f, -1.0f, 0.0f, 0.0f, 0.0f, 1.0f,
     -1.0f,  1.0f,  1.0f, -1.0f, 0.0f, 0.0f, 1.0f, 1.0f,
     /* top */
     -1.0f, 1.0f,  1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f,
-     1.0f, 1.0f,  1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 
+     1.0f, 1.0f,  1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f,
     -1.0f, 1.0f, -1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
      1.0f, 1.0f, -1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f,
     /* bottom */
     -1.0f, -1.0f, -1.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f,
-     1.0f, -1.0f, -1.0f, 0.0f, -1.0f, 0.0f, 1.0f, 0.0f, 
+     1.0f, -1.0f, -1.0f, 0.0f, -1.0f, 0.0f, 1.0f, 0.0f,
     -1.0f, -1.0f,  1.0f, 0.0f, -1.0f, 0.0f, 0.0f, 1.0f,
      1.0f, -1.0f,  1.0f, 0.0f, -1.0f, 0.0f, 1.0f, 1.0f
   };
@@ -594,9 +594,9 @@ static GLuint mkStaticf(geom_e type) {
     assert(0);
     break;
   }
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *quad_data), (const void *)0);  
-  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *quad_data), (const void *)(3 * sizeof *quad_data));  
-  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *quad_data), (const void *)(6 * sizeof *quad_data));  
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *quad_data), (const void *)0);
+  glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, (8 * sizeof *quad_data), (const void *)(3 * sizeof *quad_data));
+  glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, (8 * sizeof *quad_data), (const void *)(6 * sizeof *quad_data));
   glBindVertexArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   return ++i;
@@ -616,10 +616,10 @@ static GLfloat * mkSphereVerticesf(GLuint slices, GLuint stacks) {
     r = cos(theta);
     for(j = 0; j <= (int)slices; j++) {
       phi = j * c2MPI_Long;
-      data[k++] = -r * cos(phi); 
-      data[k++] = y; 
+      data[k++] = -r * cos(phi);
+      data[k++] = y;
       data[k++] = r * sin(phi);
-      data[k++] = phi / (2.0 * M_PI); 
+      data[k++] = phi / (2.0 * M_PI);
       data[k++] = (theta + M_PI_2) / M_PI;
     }
   }
@@ -698,14 +698,15 @@ static GL4Dvaoindex * mkRegularGridStripIndices(GLuint width, GLuint height) {
 }
 
 static inline void fcvNormals(GLfloat * p, GLfloat y, int i) {
+  (void)y; /* warning silenced */
   p[i] = 2.0f * p[i - 3] / sqrt(5.0);
-  p[i + 1] = 1.0f / sqrt(5.0); 
+  p[i + 1] = 1.0f / sqrt(5.0);
   p[i + 2] = 2.0f * p[i - 1] / sqrt(5.0);
 }
 
 static inline void fcvbNormals(GLfloat * p, GLfloat y, int i) {
   p[i] = 0;
-  p[i + 1] = y; 
+  p[i + 1] = y;
   p[i + 2] = 0;
 }
 
@@ -757,8 +758,8 @@ static GLfloat * mkConeVerticesf(GLuint slices, GLboolean base) {
     data[k++] = 0; data[k++] = 1; data[k++] = 0;
     data[k++] = (s = j / (GLdouble)slices); data[k++] = 1;
     phi = j * c2MPI_Long;
-    data[k++] = -cos(phi); 
-    data[k++] = -1; 
+    data[k++] = -cos(phi);
+    data[k++] = -1;
     data[k++] = sin(phi);
     fcvNormals(data, 0, k); k += 3;
     data[k++] = s; data[k++] = 0;
@@ -788,14 +789,14 @@ static GLfloat * mkCylinderVerticesf(GLuint slices, GLboolean base) {
   assert(data);
   for(j = 0; j <= (int)slices; j++) {
     phi = j * c2MPI_Long;
-    data[k++] = -cos(phi); 
-    data[k++] = 1; 
+    data[k++] = -cos(phi);
+    data[k++] = 1;
     data[k++] = sin(phi);
     fcvNormals(data, 0, k); k += 3;
     data[k++] = (s = j / (GLdouble)slices); data[k++] = 1;
-    data[k] = data[k - 8]; k++; 
-    data[k++] = -1; 
-    data[k] = data[k - 8]; k++; 
+    data[k] = data[k - 8]; k++;
+    data[k++] = -1;
+    data[k] = data[k - 8]; k++;
     fcvNormals(data, 0, k); k += 3;
     data[k++] = s; data[k++] = 0;
   }
@@ -831,14 +832,14 @@ static GLfloat * mkTorusVerticesf(GLuint slices, GLuint stacks, GLfloat radius) 
       phi = j * c2MPI_Long;
       x = -cos(phi);
       z = sin(phi);
-      data[k++] = (1 - radius + r) * x; 
-      data[k++] = y; 
+      data[k++] = (1 - radius + r) * x;
+      data[k++] = y;
       data[k++] = (1 - radius + r) * z;
-      data[k + 0] = data[k - 3] - (1 - radius) * x; 
-      data[k + 1] = 0; 
-      data[k + 2] = data[k - 1] - (1 - radius) * z; 
+      data[k + 0] = data[k - 3] - (1 - radius) * x;
+      data[k + 1] = 0;
+      data[k + 2] = data[k - 1] - (1 - radius) * z;
       MVEC3NORMALIZE(&data[k]); k += 3;
-      data[k++] = phi   / (2.0 * M_PI); 
+      data[k++] = phi   / (2.0 * M_PI);
       data[k++] = theta / (2.0 * M_PI);
     }
   }
@@ -869,7 +870,7 @@ static GLfloat * mkGrid2dVerticesf(GLuint width, GLuint height, GLfloat * height
       for(j = 0; j < (int)width; j++) {
 	x = -1.0 + 2.0 * (tx = j / (width - 1.0));
 	data[k++] = x;  data[k++] = 0; data[k++] = z;
-	data[k++] = 0;  data[k++] = 1; data[k++] = 0; 
+	data[k++] = 0;  data[k++] = 1; data[k++] = 0;
 	data[k++] = tx; data[k++] = tz;
       }
     }
@@ -895,7 +896,7 @@ static void mkGrid2dNormalsf(GLuint width, GLuint height, GLfloat * data) {
       for(i = 0; i < 6; i++) {
         data[8 * (x + zw) + 3] += n[3 * i + 0];
         data[8 * (x + zw) + 4] += n[3 * i + 1];
-        data[8 * (x + zw) + 5] += n[3 * i + 2]; 
+        data[8 * (x + zw) + 5] += n[3 * i + 2];
       }
       data[8 * (x + zw) + 3] /= 6.0;
       data[8 * (x + zw) + 4] /= 6.0;

--- a/lib_src/GL4D/gl4duw_SDL2.c
+++ b/lib_src/GL4D/gl4duw_SDL2.c
@@ -56,23 +56,44 @@ static inline void       manageEvents(void);
 static inline void       mainLoopBody(void * window, void ** data);
 
 /*!\brief fonction fictive liée au callback de resize de la fenêtre. */
-static inline void fake_resize(int w, int h) {}
+static inline void fake_resize(int w, int h) {
+  (void)w; /* silenced warning */
+  (void)h; /* silenced warning */
+}
 /*!\brief fonction fictive liée au callback de touche clavier enfoncée. */
-static inline void fake_keydown(int keycode) {}
+static inline void fake_keydown(int keycode) {
+  (void)keycode; /* silenced warning */
+}
 /*!\brief fonction fictive liée au callback de touche clavier relachée. */
-static inline void fake_keyup(int keycode) {}
+static inline void fake_keyup(int keycode) {
+  (void)keycode; /* silenced warning */
+}
 /*!\brief fonction fictive liée au callback d'un bouton de souris enfoncé ou relaché. */
-static inline void fake_mousebutton(int button, int state, int x, int y) {}
+static inline void fake_mousebutton(int button, int state, int x, int y) {
+  (void)button; /* silenced warning */
+  (void)state;  /* silenced warning */
+  (void)x;      /* silenced warning */
+  (void)y;      /* silenced warning */
+}
 /*!\brief fonction fictive liée au callback du mouvement de la souris avec bouton enfoncé. */
-static inline void fake_mousemotion(int x, int y) {}
+static inline void fake_mousemotion(int x, int y) {
+  (void)x; /* silenced warning */
+  (void)y; /* silenced warning */
+}
 /*!\brief fonction fictive liée au callback du mouvement de la souris sans bouton enfoncé. */
-static inline void fake_passivemousemotion(int x, int y) {}
+static inline void fake_passivemousemotion(int x, int y) {
+  (void)x; /* silenced warning */
+  (void)y; /* silenced warning */
+}
 /*!\brief fonction fictive liée au callback de l'état idle de la fenêtre. */
 static inline void fake_idle(void) {}
 /*!\brief fonction fictive liée au callback de display. */
 static inline void fake_display(void) {}
 /*!\brief fonction fictive liée au callback de catchSDL_Event. */
-static inline int  fake_catchSDL_Event(SDL_Event * event) { return 0; }
+static inline int  fake_catchSDL_Event(SDL_Event * event) {
+  (void)event; /* silenced warning */
+  return 0;
+}
 
 void gl4duwSetGLAttributes(int glMajorVersion, int glMinorVersion, int glProfileMask, int glDoubleBuffer, int glDepthSize) {
   _glMajorVersion = glMajorVersion;
@@ -82,17 +103,20 @@ void gl4duwSetGLAttributes(int glMajorVersion, int glMinorVersion, int glProfile
   _glDepthSize    = glDepthSize;
 }
 
-GLboolean gl4duwCreateWindow(int argc, char ** argv, const char * title, int x, int y, 
+GLboolean gl4duwCreateWindow(int argc, char ** argv, const char * title, int x, int y,
 		       int width, int height, Uint32 wflags) {
+  (void)x; /* silenced warning */
+  (void)y; /* silenced warning */
   SDL_Window * win = NULL;
   SDL_GLContext oglc = NULL;
-  window_t wt = { (char *)title, NULL };
+  window_t wt = {(char *)title, NULL, 0,    NULL, NULL, NULL,
+                 NULL,          NULL, NULL, NULL, NULL, NULL};
   pair_t pair;
   static int ft = 1;
   pair = btFind(&_btWindows, &wt, windowCmpFunc);
   if(!pair.compResult) {
-    fprintf(stderr, "%s (%d): %s:\n\tErreur lors de la creation de la fenetre SDL : une fenetre portant le meme nom existe deja\n", 
-	    __FILE__, __LINE__, __func__);    
+    fprintf(stderr, "%s (%d): %s:\n\tErreur lors de la creation de la fenetre SDL : une fenetre portant le meme nom existe deja\n",
+	    __FILE__, __LINE__, __func__);
     return GL_FALSE;
   }
   initGL4DUW(argc, argv);
@@ -101,15 +125,15 @@ GLboolean gl4duwCreateWindow(int argc, char ** argv, const char * title, int x, 
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, _glProfileMask);
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, _glDoubleBuffer);
   SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, _glDepthSize);
-  if( (win = SDL_CreateWindow(title, GL4DW_POS_CENTERED, GL4DW_POS_CENTERED, 
+  if( (win = SDL_CreateWindow(title, GL4DW_POS_CENTERED, GL4DW_POS_CENTERED,
 			      width, height, GL4DW_OPENGL | wflags)) == NULL ) {
-    fprintf(stderr, "%s (%d): %s:\n\tErreur lors de la creation de la fenetre SDL : %s", 
+    fprintf(stderr, "%s (%d): %s:\n\tErreur lors de la creation de la fenetre SDL : %s",
 	    __FILE__, __LINE__, __func__, SDL_GetError());
     return GL_FALSE;
   }
   if( (oglc = SDL_GL_CreateContext(win)) == NULL ) {
     SDL_DestroyWindow(win);
-    fprintf(stderr, "%s (%d): %s:\n\tErreur lors de la creation du contexte OpenGL : %s", 
+    fprintf(stderr, "%s (%d): %s:\n\tErreur lors de la creation du contexte OpenGL : %s",
 	    __FILE__, __LINE__, __func__, SDL_GetError());
     return GL_FALSE;
   }
@@ -128,7 +152,8 @@ SDL_Window * gl4duwGetSDL_Window(void) {
 }
 
 GLboolean gl4duwBindWindow(const char * title) {
-  window_t wt = { (char *)title, NULL };
+  window_t wt = {(char *)title, NULL, 0,    NULL, NULL, NULL,
+                 NULL,          NULL, NULL, NULL, NULL, NULL};
   pair_t pair;
   pair = btFind(&_btWindows, &wt, windowCmpFunc);
   if(pair.compResult)
@@ -195,12 +220,12 @@ void gl4duwDisableManageEvents(void) {
  *
  * \param argc nombre d'arguments passés au programme (premier argument de la fonction main).
  * \param argv liste des arguments passés au programme (second argument de la fonction main).
- * \return 0 en cas d'échec, !=0 sinon. 
+ * \return 0 en cas d'échec, !=0 sinon.
  */
 static inline int initGL4DUW(int argc, char ** argv) {
   if(_hasInit) return 1;
   if(SDL_Init(SDL_INIT_VIDEO) < 0) {
-    fprintf(stderr, "%s (%d): %s:\n\tErreur lors de l'initialisation de SDL :  %s", 
+    fprintf(stderr, "%s (%d): %s:\n\tErreur lors de l'initialisation de SDL :  %s",
 	    __FILE__, __LINE__, __func__, SDL_GetError());
     return 0;
   }
@@ -216,7 +241,7 @@ static inline int initGL4DUW(int argc, char ** argv) {
  * \param name titre de la fenêtre
  * \param win le pointeur vers la structure de fenêtre SDL
  * \param oglc la référence vers le contexte OpenGL lié à la fenêtre
- * \return le pointeur vers la fenêtre de type window_t créée 
+ * \return le pointeur vers la fenêtre de type window_t créée
  */
 static inline window_t * newWindow(const char * name, SDL_Window * win, SDL_GLContext oglc) {
   window_t * w = malloc(sizeof *w);
@@ -318,7 +343,18 @@ static inline void manageEvents(void) {
       break;
     case SDL_WINDOWEVENT: {
       SDL_Window * focusedw = SDL_GetWindowFromID(event.window.windowID);
-      window_t wt = { (char *)SDL_GetWindowTitle(focusedw), NULL };
+      window_t wt = {(char *)SDL_GetWindowTitle(focusedw),
+                     NULL,
+                     0,
+                     NULL,
+                     NULL,
+                     NULL,
+                     NULL,
+                     NULL,
+                     NULL,
+                     NULL,
+                     NULL,
+                     NULL};
       pair_t pair;
       pair = btFind(&_btWindows, &wt, windowCmpFunc);
       _focusedWindow = (window_t *)(*(bin_tree_t **)(pair.ptr))->data;
@@ -341,6 +377,7 @@ static inline void manageEvents(void) {
 
 /*!\brief corps de la boucle principale événement/simulation/affichage */
 static inline void mainLoopBody(void * window, void ** data) {
+  (void)data; /* warning silenced */
   window_t * w = (window_t *)window;
   w->idle();
   w->display();

--- a/lib_src/GL4D/meson.build
+++ b/lib_src/GL4D/meson.build
@@ -1,0 +1,70 @@
+srcfiles = [
+  './aes.c',
+  './bin_tree.c',
+  './fixed_heap.c',
+  './gl4da.c',
+  './gl4dfBlur.c',
+  './gl4dfCanny.c',
+  './gl4dfCommon.c',
+  './gl4dfConversion.c',
+  './gl4dfFocus.c',
+  './gl4dfFractalPainting.c',
+  './gl4dfHatching.c',
+  './gl4dfMedia.c',
+  './gl4dfMedian.c',
+  './gl4dfOp.c',
+  './gl4dfOpticalFlow.c',
+  './gl4dfScattering.c',
+  './gl4dfSegmentation.c',
+  './gl4dfSobel.c',
+  './gl4dg.c',
+  './gl4dhAnimeManager.c',
+  './gl4dm.c',
+  './gl4dp.c',
+  './gl4dq.c',
+  './gl4droid.c',
+  './gl4du.c',
+  './gl4dummies.c',
+  './gl4duw_SDL2.c',
+  './linked_list.c',
+  './list.c',
+  './vector.c',
+]
+
+header_files = [
+  './fixed_heap.h',
+  './gl4duw_SDL2.h',
+  './gl4dq.h',
+  './gl4wdummies.h',
+  './vector.h',
+  './gl4da.h',
+  './gl4dg.h',
+  './gl4dummies.h',
+  './linked_list.h',
+  './gl4dfCommon.h',
+  './gl4dp.h',
+  './gl4du.h',
+  './list.h',
+  './gl4df.h',
+  './gl4dhAnimeManager.h',
+  './gl4dm.h',
+  './aes.h',
+  './gl4dfBlurWeights.h',
+  './gl4dh.h',
+  './gl4droid.h',
+  './bin_tree.h',
+]
+
+lib_args = ['-DBUILDING_GL4DUMMIES']
+
+cc = meson.get_compiler('c')
+m_dep = cc.find_library('m', required: true)
+sdl2_dep = dependency('sdl2')
+gl_dep = dependency('gl')
+
+shlib = shared_library('GL4Dummies', srcfiles,
+                       install: true,
+                       c_args: lib_args,
+                       dependencies: [m_dep, sdl2_dep, gl_dep])
+
+install_headers(header_files, subdir: 'GL4D')

--- a/lib_src/meson.build
+++ b/lib_src/meson.build
@@ -1,0 +1,1 @@
+subdir('GL4D')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,89 @@
+project('GL4Dummies', 'c',
+        version: '6.0.0',
+        default_options: ['c_std=gnu99', 'warning_level=2'])
+
+lib_args = ['-DBUILDING_GL4DUMMIES']
+
+srcfiles = [
+  'lib_src/GL4D/gl4droid.c',
+  'lib_src/GL4D/linked_list.c',
+  'lib_src/GL4D/gl4dfCommon.c',
+  'lib_src/GL4D/gl4dq.c',
+  'lib_src/GL4D/gl4dfScattering.c',
+  'lib_src/GL4D/fixed_heap.c',
+  'lib_src/GL4D/gl4dfSegmentation.c',
+  'lib_src/GL4D/gl4dp.c',
+  'lib_src/GL4D/gl4dfConversion.c',
+  'lib_src/GL4D/gl4da.c',
+  'lib_src/GL4D/gl4dfOp.c',
+  'lib_src/GL4D/gl4dfMedian.c',
+  'lib_src/GL4D/gl4dfBlur.c',
+  'lib_src/GL4D/gl4duw_SDL2.c',
+  'lib_src/GL4D/gl4dfFractalPainting.c',
+  'lib_src/GL4D/gl4dfHatching.c',
+  'lib_src/GL4D/gl4dfOpticalFlow.c',
+  'lib_src/GL4D/gl4dfFocus.c',
+  'lib_src/GL4D/gl4dummies.c',
+  'lib_src/GL4D/gl4dg.c',
+  'lib_src/GL4D/aes.c',
+  'lib_src/GL4D/gl4dfCanny.c',
+  'lib_src/GL4D/gl4dhAnimeManager.c',
+  'lib_src/GL4D/list.c',
+  'lib_src/GL4D/bin_tree.c',
+  'lib_src/GL4D/gl4dfMedia.c',
+  'lib_src/GL4D/gl4dfSobel.c',
+  'lib_src/GL4D/gl4dm.c',
+  'lib_src/GL4D/gl4du.c',
+  'lib_src/GL4D/vector.c',
+]
+
+cc = meson.get_compiler('c')
+m_dep = cc.find_library('m', required: true)
+sdl2_dep = dependency('sdl2')
+gl_dep = dependency('gl')
+
+shlib = shared_library('gl4dummies', srcfiles,
+  install: true,
+  c_args: lib_args,
+  gnu_symbol_visibility: 'hidden',
+  dependencies: [m_dep, sdl2_dep, gl_dep],
+  )
+
+gl4dummies_dep = declare_dependency(
+  include_directories: 'lib_src/GL4D/',
+  link_with: shlib)
+
+header_files = [
+  'lib_src/GL4D/fixed_heap.h',
+  'lib_src/GL4D/gl4duw_SDL2.h',
+  'lib_src/GL4D/gl4dq.h',
+  'lib_src/GL4D/gl4wdummies.h',
+  'lib_src/GL4D/vector.h',
+  'lib_src/GL4D/gl4da.h',
+  'lib_src/GL4D/gl4dg.h',
+  'lib_src/GL4D/gl4dummies.h',
+  'lib_src/GL4D/linked_list.h',
+  'lib_src/GL4D/gl4dfCommon.h',
+  'lib_src/GL4D/gl4dp.h',
+  'lib_src/GL4D/gl4du.h',
+  'lib_src/GL4D/list.h',
+  'lib_src/GL4D/gl4df.h',
+  'lib_src/GL4D/gl4dhAnimeManager.h',
+  'lib_src/GL4D/gl4dm.h',
+  'lib_src/GL4D/aes.h',
+  'lib_src/GL4D/gl4dfBlurWeights.h',
+  'lib_src/GL4D/gl4dh.h',
+  'lib_src/GL4D/gl4droid.h',
+  'lib_src/GL4D/bin_tree.h',
+]
+
+install_headers(header_files, subdir: 'GL4D')
+
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(
+  name: 'GL4Dummies',
+  filebase: 'gl4dummies',
+  description: 'GL4Dummies is an API that aims to help C developers to easily produce Multi-platform OpenGL 3.3+ applications.',
+  libraries: shlib,
+  version: '6.0.0',
+  )

--- a/meson.build
+++ b/meson.build
@@ -87,5 +87,5 @@ pkg_mod.generate(
   libraries: shlib,
   version: '6.0.0',
   requires: ['gl', 'sdl2'],
-  install_dir: '/usr/lib/pkgconfig/'
+  # install_dir: '/usr/lib/pkgconfig/'
 )

--- a/meson.build
+++ b/meson.build
@@ -42,7 +42,7 @@ m_dep = cc.find_library('m', required: true)
 sdl2_dep = dependency('sdl2')
 gl_dep = dependency('gl')
 
-shlib = shared_library('gl4dummies', srcfiles,
+shlib = shared_library('GL4Dummies', srcfiles,
   install: true,
   c_args: lib_args,
   gnu_symbol_visibility: 'hidden',
@@ -82,8 +82,10 @@ install_headers(header_files, subdir: 'GL4D')
 pkg_mod = import('pkgconfig')
 pkg_mod.generate(
   name: 'GL4Dummies',
-  filebase: 'gl4dummies',
-  description: 'GL4Dummies is an API that aims to help C developers to easily produce Multi-platform OpenGL 3.3+ applications.',
+  filebase: 'GL4Dummies',
+  description: 'C wrapper around OpenGL 3.3+',
   libraries: shlib,
   version: '6.0.0',
-  )
+  requires: ['gl', 'sdl2'],
+  install_dir: '/usr/lib/pkgconfig/'
+)

--- a/meson.build
+++ b/meson.build
@@ -2,90 +2,15 @@ project('GL4Dummies', 'c',
         version: '6.0.0',
         default_options: ['c_std=gnu99', 'warning_level=2'])
 
-lib_args = ['-DBUILDING_GL4DUMMIES']
+subdir('lib_src')
 
-srcfiles = [
-  'lib_src/GL4D/gl4droid.c',
-  'lib_src/GL4D/linked_list.c',
-  'lib_src/GL4D/gl4dfCommon.c',
-  'lib_src/GL4D/gl4dq.c',
-  'lib_src/GL4D/gl4dfScattering.c',
-  'lib_src/GL4D/fixed_heap.c',
-  'lib_src/GL4D/gl4dfSegmentation.c',
-  'lib_src/GL4D/gl4dp.c',
-  'lib_src/GL4D/gl4dfConversion.c',
-  'lib_src/GL4D/gl4da.c',
-  'lib_src/GL4D/gl4dfOp.c',
-  'lib_src/GL4D/gl4dfMedian.c',
-  'lib_src/GL4D/gl4dfBlur.c',
-  'lib_src/GL4D/gl4duw_SDL2.c',
-  'lib_src/GL4D/gl4dfFractalPainting.c',
-  'lib_src/GL4D/gl4dfHatching.c',
-  'lib_src/GL4D/gl4dfOpticalFlow.c',
-  'lib_src/GL4D/gl4dfFocus.c',
-  'lib_src/GL4D/gl4dummies.c',
-  'lib_src/GL4D/gl4dg.c',
-  'lib_src/GL4D/aes.c',
-  'lib_src/GL4D/gl4dfCanny.c',
-  'lib_src/GL4D/gl4dhAnimeManager.c',
-  'lib_src/GL4D/list.c',
-  'lib_src/GL4D/bin_tree.c',
-  'lib_src/GL4D/gl4dfMedia.c',
-  'lib_src/GL4D/gl4dfSobel.c',
-  'lib_src/GL4D/gl4dm.c',
-  'lib_src/GL4D/gl4du.c',
-  'lib_src/GL4D/vector.c',
-]
-
-cc = meson.get_compiler('c')
-m_dep = cc.find_library('m', required: true)
-sdl2_dep = dependency('sdl2')
-gl_dep = dependency('gl')
-
-shlib = shared_library('GL4Dummies', srcfiles,
-  install: true,
-  c_args: lib_args,
-  gnu_symbol_visibility: 'hidden',
-  dependencies: [m_dep, sdl2_dep, gl_dep],
-  )
-
-gl4dummies_dep = declare_dependency(
-  include_directories: 'lib_src/GL4D/',
-  link_with: shlib)
-
-header_files = [
-  'lib_src/GL4D/fixed_heap.h',
-  'lib_src/GL4D/gl4duw_SDL2.h',
-  'lib_src/GL4D/gl4dq.h',
-  'lib_src/GL4D/gl4wdummies.h',
-  'lib_src/GL4D/vector.h',
-  'lib_src/GL4D/gl4da.h',
-  'lib_src/GL4D/gl4dg.h',
-  'lib_src/GL4D/gl4dummies.h',
-  'lib_src/GL4D/linked_list.h',
-  'lib_src/GL4D/gl4dfCommon.h',
-  'lib_src/GL4D/gl4dp.h',
-  'lib_src/GL4D/gl4du.h',
-  'lib_src/GL4D/list.h',
-  'lib_src/GL4D/gl4df.h',
-  'lib_src/GL4D/gl4dhAnimeManager.h',
-  'lib_src/GL4D/gl4dm.h',
-  'lib_src/GL4D/aes.h',
-  'lib_src/GL4D/gl4dfBlurWeights.h',
-  'lib_src/GL4D/gl4dh.h',
-  'lib_src/GL4D/gl4droid.h',
-  'lib_src/GL4D/bin_tree.h',
-]
-
-install_headers(header_files, subdir: 'GL4D')
+gl4dummies_dep = declare_dependency(include_directories: 'lib_src/GL4D/',
+                                    link_with: shlib)
 
 pkg_mod = import('pkgconfig')
-pkg_mod.generate(
-  name: 'GL4Dummies',
-  filebase: 'GL4Dummies',
-  description: 'C wrapper around OpenGL 3.3+',
-  libraries: shlib,
-  version: '6.0.0',
-  requires: ['gl', 'sdl2'],
-  # install_dir: '/usr/lib/pkgconfig/'
-)
+pkg_mod.generate(name: 'GL4Dummies',
+                 filebase: 'GL4Dummies',
+                 description: 'C wrapper around OpenGL 3.3+',
+                 libraries: shlib,
+                 version: '6.0.0',
+                 requires: ['gl', 'sdl2'])

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('GL4Dummies', 'c',
         version: '6.0.0',
-        default_options: ['c_std=gnu99', 'warning_level=2', 'optimization=3', 
-                          'buildtype=release', 'strip=true'])
+        default_options: ['c_std=gnu99', 'warning_level=2', 'optimization=3',
+                          'buildtype=release'])
 
 subdir('lib_src')
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('GL4Dummies', 'c',
         version: '6.0.0',
-        default_options: ['c_std=gnu99', 'warning_level=2'])
+        default_options: ['c_std=gnu99', 'warning_level=2', 'optimization=3', 
+                          'buildtype=release', 'strip=true'])
 
 subdir('lib_src')
 


### PR DESCRIPTION
Comme mentionné dans l’issue #3, j’ai ajouté les fichiers nécessaires à la compilation de GL4Dummies avec le système de compilation Meson. Pour l’instant, cela ne fonctionne et n’a été testé que sous macOS et Linux (j’ai implémenté et testé les changements sous Arch Linux et Travis-CI teste sous Ubuntu et macOS). La compilation sous Windows n’a pas encore été réellement testée, et la compilation d’éléments autres que la bibliothèque en elle-même (documentation, samples) n’est pas encore supportée.