### PR TITLE
Adding the latest window flags to GL4D

### DIFF
--- a/lib_src/GL4D/gl4duw_SDL2.h
+++ b/lib_src/GL4D/gl4duw_SDL2.h
@@ -277,27 +277,35 @@
 /*!\brief window not created by SDL */
 #define GL4DW_FOREIGN SDL_WINDOW_FOREIGN
 /* window flags on later versions */
-#if SDL_MINOR_VERSION > 0 || SDL_PATCHLEVEL >= 1
+#ifdef SDL_WINDOW_ALLOW_HIGHDPI
   /*!\brief window should be created in high-DPI mode if supported (On macOS NSHighResolutionCapable must be set true in the application's Info.plist for this to have any effect, >= SDL 2.0.1) */
   #define GL4DW_ALLOW_HIGHDPI SDL_WINDOW_ALLOW_HIGHDPI
 #endif
-#if SDL_MINOR_VERSION > 0 || SDL_PATCHLEVEL >= 4
+#ifdef SDL_WINDOW_MOUSE_CAPTURE
   /*!\brief window has mouse captured (unrelated to INPUT_GRABBED, >= SDL 2.0.4) */
   #define GL4DW_MOUSE_CAPTURE SDL_WINDOW_MOUSE_CAPTURE
 #endif
-#if SDL_MINOR_VERSION > 0 || SDL_PATCHLEVEL >= 5
+#ifdef SDL_WINDOW_ALWAYS_ON_TOP
   /*!\brief window should always be above others (X11 only, >= SDL 2.0.5) */
   #define GL4DW_ALWAYS_ON_TOP SDL_WINDOW_ALWAYS_ON_TOP
+#endif
+#ifdef SDL_WINDOW_SKIP_TASKBAR
   /*!\brief window should not be added to the taskbar (X11 only, >= SDL 2.0.5) */
   #define GL4DW_SKIP_TASKBAR SDL_WINDOW_SKIP_TASKBAR
+#endif
+#ifdef SDL_WINDOW_UTILITY
   /*!\brief window should be treated as a utility window (X11 only, >= SDL 2.0.5) */
   #define GL4DW_UTILITY SDL_WINDOW_UTILITY
+#endif
+#ifdef SDL_WINDOW_TOOLTIP
   /*!\brief window should be treated as a tooltip (X11 only, >= SDL 2.0.5) */
   #define GL4DW_TOOLTIP SDL_WINDOW_TOOLTIP
+#endif
+#ifdef SDL_WINDOW_POPUP_MENU
   /*!\brief window should be treated as a popup menu (X11 only, >= SDL 2.0.5) */
   #define GL4DW_POPUP_MENU SDL_WINDOW_POPUP_MENU
 #endif
-#if SDL_MINOR_VERSION > 0 || SDL_PATCHLEVEL >= 6
+#ifdef SDL_WINDOW_VULKAN
   /*!\brief window usable with a Vulkan instance (may be X11 only, >= SDL 2.0.6) */
   #define GL4DW_VULKAN SDL_WINDOW_VULKAN
 #endif

--- a/lib_src/GL4D/gl4duw_SDL2.h
+++ b/lib_src/GL4D/gl4duw_SDL2.h
@@ -276,8 +276,31 @@
 #define GL4DW_FULLSCREEN_DESKTOP SDL_WINDOW_FULLSCREEN_DESKTOP
 /*!\brief window not created by SDL */
 #define GL4DW_FOREIGN SDL_WINDOW_FOREIGN
-/*!\brief window should be created in high-DPI mode if supported */
-#define GL4DW_ALLOW_HIGHDPI SDL_WINDOW_ALLOW_HIGHDPI
+/* window flags on later versions */
+#if SDL_MINOR_VERSION > 0 || SDL_PATCHLEVEL >= 1
+  /*!\brief window should be created in high-DPI mode if supported (On macOS NSHighResolutionCapable must be set true in the application's Info.plist for this to have any effect, >= SDL 2.0.1) */
+  #define GL4DW_ALLOW_HIGHDPI SDL_WINDOW_ALLOW_HIGHDPI
+#endif
+#if SDL_MINOR_VERSION > 0 || SDL_PATCHLEVEL >= 4
+  /*!\brief window has mouse captured (unrelated to INPUT_GRABBED, >= SDL 2.0.4) */
+  #define GL4DW_MOUSE_CAPTURE SDL_WINDOW_MOUSE_CAPTURE
+#endif
+#if SDL_MINOR_VERSION > 0 || SDL_PATCHLEVEL >= 5
+  /*!\brief window should always be above others (X11 only, >= SDL 2.0.5) */
+  #define GL4DW_ALWAYS_ON_TOP SDL_WINDOW_ALWAYS_ON_TOP
+  /*!\brief window should not be added to the taskbar (X11 only, >= SDL 2.0.5) */
+  #define GL4DW_SKIP_TASKBAR SDL_WINDOW_SKIP_TASKBAR
+  /*!\brief window should be treated as a utility window (X11 only, >= SDL 2.0.5) */
+  #define GL4DW_UTILITY SDL_WINDOW_UTILITY
+  /*!\brief window should be treated as a tooltip (X11 only, >= SDL 2.0.5) */
+  #define GL4DW_TOOLTIP SDL_WINDOW_TOOLTIP
+  /*!\brief window should be treated as a popup menu (X11 only, >= SDL 2.0.5) */
+  #define GL4DW_POPUP_MENU SDL_WINDOW_POPUP_MENU
+#endif
+#if SDL_MINOR_VERSION > 0 || SDL_PATCHLEVEL >= 6
+  /*!\brief window usable with a Vulkan instance (may be X11 only, >= SDL 2.0.6) */
+  #define GL4DW_VULKAN SDL_WINDOW_VULKAN
+#endif
 /* window coordinates */
 /*!\brief Used to indicate that you don't care what the window position is.*/
 #define GL4DW_POS_UNDEFINED SDL_WINDOWPOS_UNDEFINED


### PR DESCRIPTION
_(If you dont want to read, there is a TL;DR at the end of this message)_

Issue #7 was alerting us about the fact that some functions using flags may have undefined GL4D-prefixed macros. Forcing us to use the SDL ones. But even if it wasn't the case in Issue #7 (since there was a little confusion), it tickled me. So i verified the actual state of `gl4duwCreateWindow` flags and some of them are actually missing. I've added them, added some security and some comments to the doc.

### Addition

- `GL4DW_MOUSE_CAPTURE` from `SDL_WINDOW_MOUSE_CAPTURE` (added in SDL 2.0.4)
- `GL4DW_ALWAYS_ON_TOP` from `SDL_WINDOW_ALWAYS_ON_TOP` (added in SDL 2.0.5)
- `GL4DW_SKIP_TASKBAR` from `SDL_WINDOW_SKIP_TASKBAR` (added in SDL 2.0.5)
- `GL4DW_UTILITY` from `SDL_WINDOW_UTILITY` (added in SDL 2.0.5)
- `GL4DW_TOOLTIP` from `SDL_WINDOW_TOOLTIP` (added in SDL 2.0.5)
- `GL4DW_POPUP_MENU` from `SDL_WINDOW_POPUP_MENU` (added in SDL 2.0.5)
- `GL4DW_VULKAN` from `SDL_WINDOW_VULKAN` (added in SDL 2.0.6)
- Doxygen comments for each addition (taken directly from the `SDL_video.h` source code for reliability and consistency)
- Details for macOS that were missing in the comment of `GL4DW_ALLOW_HIGHDPI` (again from `SDL_video.h`)

### Security

I've surrounded each new macro with an `#if` to verify if we are in the right version (or after). Basically, if we arn't, the macro isn't defined. I did the same with `GL4DW_ALLOW_HIGHDPI` (that already was in the code before this PR) since that macro was originally added in SDL 2.0.1.

Some would argue that this "protection" is pointless since if we're not in the right SDL version and we try to use these new GL4D flags, well, we're gonna have an error anyway. But i beg to differ. If someone from, let's say, SDL 2.0.0, were to use any of the new flags _without_ this security, the compiler would probably say something like _"Bro, what the heck is **SDL**_MACRO ?"_ instead of _"Bro, what the heck is **GL4D**_MACRO ?"_ which could be confusing. Especially for begginners on an API that is aims at them.

### Issues

When a macro was added after the 2.0.0 version, it's mentionned in the doc. But the official documentation dont even mention the fact that `GL4DW_VULKAN` was added in 2.0.6. It's just not there (sigh). I had to manually check it since it seemed wierd to me that Vulkan was already there when the first version of SDL2 came out.

The problem being, if the official doc is incomplete concerning the feature activated by one of its macro, there is other things we might be missing too. For exemple, every macro added from SDL 2.0.5 seems to require X11. And i have no way to know if it's the same for `GL4DW_VULKAN`. I had to add "may be X11 only" which i pretty ridiculous if you ask me.

Tbh, i dont see why Vulkan would need X11. But i cant just ignore the fact that it might be ! 

That's all for me ! Have a nice day !

## TL;DR

Just adding missing macros, lol