### PR TITLE
Correcting some warnings (bad types in comparisons + a lack of assert)

### DIFF
--- a/lib_src/GL4D/aes.c
+++ b/lib_src/GL4D/aes.c
@@ -912,7 +912,7 @@ extern char * aes_from_tar(const char * file) {
     free(data);
     return NULL;
   }
-  if( (l = fread(data, sizeof * data, buf.st_size, f)) != buf.st_size) {
+  if( (l = fread(data, sizeof * data, buf.st_size, f)) != (size_t)buf.st_size) {
     fprintf(stderr, "%s:%d:In %s: une erreur s'est produite lors de la lecture du fichier %s\n",
 	    __FILE__, __LINE__, __func__, file);
     free(data);

--- a/lib_src/GL4D/gl4dfCanny.c
+++ b/lib_src/GL4D/gl4dfCanny.c
@@ -116,7 +116,7 @@ static inline void ccl(GLuint tex) {
       while(!queueEmpty()) {
 	GLint j, q = queueGet(), x, y;
 	x = (q >> 2); y = x / w; x = x % w;
-	for(j = 0; j < sizeof d / sizeof *d; ++j) {
+	for(j = 0; j < (GLint)(sizeof d / sizeof *d); ++j) {
 	  GLint nx = x + d2[j][0], ny = y + d2[j][1], nq = q + d[j];
 	  if(nx >= 0 && ny >= 0 && nx < w && ny < h &&
 	     !_marks[nq]) {

--- a/lib_src/GL4D/gl4dm.c
+++ b/lib_src/GL4D/gl4dm.c
@@ -126,6 +126,7 @@ static void triangle_edge(GLfloat *im, int x, int y, int w, int h, int width, GL
  */
 GLfloat * gl4dmTriangleEdge(GLuint width, GLuint height, GLfloat H) {
   GLfloat * hm = calloc(width * height, sizeof *hm);
+  assert(hm);
   hm[0] = GL4DM_EPSILON + gl4dmURand();
   hm[width - 1] = GL4DM_EPSILON + gl4dmURand();
   hm[(height - 1) * width + width - 1] = GL4DM_EPSILON + gl4dmURand();

--- a/lib_src/GL4D/gl4dm.h
+++ b/lib_src/GL4D/gl4dm.h
@@ -16,6 +16,7 @@
 #include "gl4dummies.h"
 
 #include <math.h>
+#include <assert.h>
 
 /* MACROS DIVERS */
 


### PR DESCRIPTION
Just correcting some minor issues appearing in warnings when compiling the library. Nothing to brag about.

See the details in Issue #8 and Issue #15