### PR TITLE
add resize function to anime manager

### DIFF
--- a/lib_src/GL4D/gl4dhAnimeManager.c
+++ b/lib_src/GL4D/gl4dhAnimeManager.c
@@ -133,6 +133,21 @@ void gl4dhUpdateWithAudio(void) {
   drawOrUpdateWithAudio(_animations, GL4DH_UPDATE_WITH_AUDIO);
 }
 
+/*!\brief met à jour la largeur et la hauteur de la texture dans laquelle sont
+ * réalisées les animations.
+ */
+void gl4dhResize(int w, int h) {
+  _w = w; _h = h;
+
+  glBindTexture(GL_TEXTURE_2D, _wTexId);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+
+  glBindTexture(GL_TEXTURE_2D, _wdTexId);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, w, h, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_BYTE, NULL);
+  
+  glBindTexture(GL_TEXTURE_2D, 0);
+}
+
 /*!\brief regarde si le pointeur \a func est un élément du tableau
  * \a funcList 
  * \param func un élément dont il faut tester la présence.

--- a/lib_src/GL4D/gl4dhAnimeManager.h
+++ b/lib_src/GL4D/gl4dhAnimeManager.h
@@ -37,6 +37,7 @@ extern "C" {
   GL4DAPI Uint32 GL4DAPIENTRY gl4dhGetTicks(void);
   GL4DAPI void   GL4DAPIENTRY gl4dhDraw(void);
   GL4DAPI void   GL4DAPIENTRY gl4dhUpdateWithAudio(void);
+  GL4DAPI void   GL4DAPIENTRY gl4dhResize(int w, int h);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This pull request follows issue #35.

We want to allow users of the anime manager to resize the window while keeping correct proportions of the animations.

The issue shows an example of how to use this function.