### PR TITLE
Ajouter une image Docker contenant toutes les dépendances de GL4Dummies #39

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:20.04
+
+ENV TZ=Europe/Paris
+
+RUN ln -fs /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && apt-get install -y \
+    git \
+    build-essential \
+    libsdl2-dev \
+    libsdl2-image-dev \
+    libsdl2-mixer-dev \
+    libsdl2-ttf-dev \
+    pkg-config \
+    autotools-dev \
+    autoconf \
+    automake \
+    libtool \
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y mesa-utils
+
+RUN git clone https://github.com/noalien/GL4Dummies.git /opt/GL4Dummies \
+    && cd /opt/GL4Dummies \
+    && make -f Makefile.autotools \
+    && ./configure \
+    && make \
+    && make install
+
+ENV XDG_RUNTIME_DIR=/tmp/runtime
+RUN mkdir -p /tmp/runtime
+
+ENV PATH="/usr/local/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/local/lib"
+
+
+WORKDIR /workspace
+
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -102,13 +102,14 @@ docker run -it --rm \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
   -v $(pwd):/workspace \
   gl4
-
+```
 ### Test an example inside the container:
 
 ```bash
 cd samples/sample3d_01-1.6
 make
 ./sample3d
+```
 
 
 ## Online instructions

--- a/README.md
+++ b/README.md
@@ -81,6 +81,37 @@ set -gx PATH $HOME/local/bin $PATH
 set -gx LD_LIBRARY_PATH $HOME/local/lib $LD_LIBRARY_PATH
 ```
 
+
+## Docker Usage (Debian-based Linux only)
+
+GL4Dummies can also be built and run using Docker, which comes pre-configured with all necessary dependencies.  
+This method has been tested on Debian-based Linux distributions like **Ubuntu** and **Kali Linux**.
+
+### Requirements
+
+Make sure that **X11 forwarding** is enabled on your host system.
+
+---
+
+### Build and run the container:
+
+```bash
+xhost +
+docker build . -t gl4
+docker run -it --rm \
+  -e DISPLAY=$DISPLAY \
+  -v /tmp/.X11-unix:/tmp/.X11-unix \
+  -v $(pwd):/workspace \
+  gl4
+
+### Test an example inside the container:
+
+```bash
+cd samples/sample3d_01-1.6
+make
+./sample3d
+
+
 ## Online instructions
 You can also refer to the manual ([PDF](http://gl4d.api8.fr/FR/gl4d.pdf)) for more in-depth instructions (in
 French).

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ set -gx LD_LIBRARY_PATH $HOME/local/lib $LD_LIBRARY_PATH
 ## Docker Usage (Debian-based Linux only)
 
 GL4Dummies can also be built and run using Docker, which comes pre-configured with all necessary dependencies.  
-This method has been tested on Debian-based Linux distributions like **Ubuntu** and **Kali Linux**.
 
 ### Requirements
 


### PR DESCRIPTION
ajout un fichier Dockerfile permettant de compiler et exécuter le projet GL4Dummies dans un conteneur Docker préconfiguré.

Modifications apportées :

Ajout d’un Dockerfile avec toutes les dépendances nécessaires.

Mise à jour du README.md avec :

les instructions d’utilisation de Docker,

un exemple de test avec sample3d_01-1.6.

Tests effectués sur :

Kali Linux

Ubuntu 20.04

Avantages :

Plus besoin d’installer les dépendances manuellement.

Environnement de développement reproductible et portable.