### PR TITLE
fix 11_jack_audio example and add another visualisation for it

### DIFF
--- a/samples/samples_demoHelper/11_jack_audio/README.md
+++ b/samples/samples_demoHelper/11_jack_audio/README.md
@@ -1,0 +1,30 @@
+# Dépendances
+
+Ce programme nécéssite d'installer *fftw* et *jack* pour fonctionner
+
+## Installer fftw
+
+- Arch linux: `pacman -S fftw`
+- Debian: `apt-get install fftw2 fftw-dev`
+
+## Installer jack
+
+Jack est un serveur audio permettant la création de "clients" audio avec des entrées et des sorties, et de les connecter entre elles.
+Ici, jack est utilisé pour créer un client avec une entrée, utilisée pour lire un signal sonore en temps réel.
+
+
+En plus de jack, on conseille l'utilisation d'un client graphique pour pouvoir configurer jack mais surtout connecter/déconnecter simplement les entrées/sorties que l'on veut connecter. Il existe plusieurs clients graphique, nous conseillons ici **qjackctl** qui est simple et performant.
+
+### Sans pipewire
+
+- Arch linux: `pacman -S jack2 qjackctl`
+- Debian: `apt-get install libjack-jackd2-dev jackd2 qjackctl`
+
+### Avec pipewire
+
+Si vous utilisez **pipewire**, remplacez le paquet jack2 par le sous-paquet jack lié à pipewire (en général nommé **pipewire-jack**).
+
+Si vous ne savez pas si votre ordinateur utilise pipewire, vous pouvez vérifier si le service est actif sur votre machine: `systemctl --user status pipewire.service`
+
+- Arch linux: `pacman -S pipewire-jack qjackctl`
+- Debian: `apt-get install libjack-jackd2-dev pipewire-jack qjackctl`

--- a/samples/samples_demoHelper/11_jack_audio/window.c
+++ b/samples/samples_demoHelper/11_jack_audio/window.c
@@ -32,7 +32,7 @@ static void quit(void);
 /*!\brief nombre de bandes de fréquences stockées */
 #define FREQUENCES (ECHANTILLONS >> 2)
 /*!\brief amplitude des échantillons du signal sonore */
-static jack_default_audio_sample_t _samples[ECHANTILLONS];
+static float _samples[ECHANTILLONS];
 /*!\brief amplitude des fréquences du signal sonore */
 static Sint16 _hauteurs[FREQUENCES];
 /*!\brief dimensions de la fenêtre */
@@ -91,35 +91,43 @@ static void init(const char * clientname) {
   }
 }
 
+
+/*!\brief dessine la forme d'onde dans le contexte OpenGL actif */
+static void drawwave(void) {
+  for(int i = 0; i < ECHANTILLONS; ++i) {
+    int x0 = (i * (_wW - 1)) / (ECHANTILLONS - 1);
+    int y0 = (_samples[i] * _wH + _wH) / 2;
+
+    if(y0 > _wH) y0 = _wH - 1;
+    if(y0 < 0) y0 = 0;
+      
+    gl4dpPutPixel(x0, y0);
+  }
+}
+
+/*!\brief dessine les bandes de fréquences dans le contexte OpenGL actif */
+static void drawfftw(void) {
+  for(int i = 0; i < FREQUENCES; ++i) {
+    int x0 = (i * (_wW - 1)) / (FREQUENCES - 1);
+    int y0 = _hauteurs[i];
+
+    if(y0 > _wH) y0 = _wH - 1;
+    if(y0 < 0) y0 = 0;
+      
+    gl4dpPutPixel(x0, y0);
+  }
+}
+
 /*!\brief dessine dans le contexte OpenGL actif */
 static void draw(void) {
-  int i;
   gl4dpSetColor(RGB(255, 255, 255));
   gl4dpSetScreen(_screen);
   gl4dpClearScreen();
 
   if (waveform == 1) {
-    // affichage de la forme d'onde
-    for(i = 0; i < ECHANTILLONS; ++i) {
-      int x0 = (i * (_wW - 1)) / (ECHANTILLONS - 1);
-      int y0 = (_samples[i] * _wH + _wH) / 2;
-
-      if(y0 > _wH) y0 = _wH - 1;
-      if(y0 < 0) y0 = 0;
-      
-      gl4dpPutPixel(x0, y0);
-    }
+    drawwave();
   } else {
-    // affichage des bandes de fréquences
-    for(i = 0; i < FREQUENCES; ++i) {
-      int x0 = (i * (_wW - 1)) / (FREQUENCES - 1);
-      int y0 = _hauteurs[i];
-
-      if(y0 > _wH) y0 = _wH - 1;
-      if(y0 < 0) y0 = 0;
-      
-      gl4dpPutPixel(x0, y0);
-    }
+    drawfftw();
   }
   gl4dpUpdateScreen(NULL);
 }
@@ -143,31 +151,27 @@ static void keydown(int keycode) {
   }
 }
 
-/*!\brief fonction appellée par jack liée au client jack
- * les données d'entrée du port \ref _input sont récupérées dans
- * \a buffer. Ce buffer a une aille \a nframes
- */
-static int mixCallback(jack_nframes_t nframes, void * arg) {
+
+/*!\brief remplit un tableau '_samples' de taille fixe */
+static void fillwave(float * buffer, int nframes) {
+  if(nframes > ECHANTILLONS) {
+    for(int i = 0; i < ECHANTILLONS; ++i)
+      _samples[i] = buffer[i];
+  } else {
+    // si 'buffer' a une taille inférieur à notre tableau _samples de taille fixe,
+    // on bouge les données précédentes pour faire avancer le signal de 'nframes' échantillons
+    for(int i = nframes; i < ECHANTILLONS; ++i)
+      _samples[i - nframes] = _samples[i];
+
+    int end = ECHANTILLONS - nframes;
+    for(int i = 0; i < nframes; ++i)
+      _samples[i + end] = buffer[i];
+  }
+}
+
+/*!\brief calcule la transformée de fourier sur le tableau '_samples' */
+static void processfftw(void) {
   if(_plan4fftw) {
-    jack_default_audio_sample_t * buffer = jack_port_get_buffer((jack_port_t*)arg, nframes);
-
-    // 'buffer' peut avoir une taille variant de 16 à 4096 échantillons,
-    // donc nous stockons les données dans un tableau '_samples' de taille fixe. 
-    if(nframes > ECHANTILLONS) {
-      for(int i = 0; i < ECHANTILLONS; ++i)
-        _samples[i] = buffer[i];
-    } else {
-      // si 'buffer' a une taille inférieur à notre tableau _samples de taille fixe,
-      // on bouge les données précédentes pour faire avancer le signal de 'nframes' échantillons
-      for(int i = nframes; i < ECHANTILLONS; ++i)
-        _samples[i - nframes] = _samples[i];
-
-      int end = ECHANTILLONS - nframes;
-      for(int i = 0; i < nframes; ++i)
-        _samples[i + end] = buffer[i];
-    }
-
-    // on calcule la transformée de fourier sur le tableau '_samples' de taille fixe
     int i;
     for(i = 0; i < ECHANTILLONS; i++)
       _in4fftw[i][0] = _samples[i];
@@ -177,6 +181,17 @@ static int mixCallback(jack_nframes_t nframes, void * arg) {
     for(i = 0; i < FREQUENCES; i++)
       _hauteurs[i] = (int)(sqrt(_out4fftw[i][0] * _out4fftw[i][0] + _out4fftw[i][1] * _out4fftw[i][1]) * exp(2.0 * i / (double)(FREQUENCES)));
   }
+}
+
+/*!\brief fonction appellée par jack liée au client jack
+ * les données d'entrée du port \ref _input sont récupérées dans
+ * \a buffer. Ce buffer a une aille \a nframes
+ */
+static int mixCallback(jack_nframes_t nframes, void * arg) {
+  float * buffer = jack_port_get_buffer((jack_port_t*)arg, nframes);
+
+  fillwave(buffer, nframes);
+  processfftw();
 
   return 0;
 }


### PR DESCRIPTION
11_jack_audio was buggy and didn't show the correct fourier transform visualization. This corrects it while also making it more precise, and bringing another visualization for the waveform, to give some new ideas of what could be used in visuals.

Also, some comments were added to explain a bit of what's going on (in french, to fully respect what seems like the guidelines)

Here's the bug that would happen before if your jack settings weren't perfectly matching the program prerequisites:

https://github.com/user-attachments/assets/34316121-925b-42cb-abe9-106fadba64e0


With the fix:

https://github.com/user-attachments/assets/fd9bcf03-2c4e-4201-9cf4-ec7379e68205

And the new visualization:

https://github.com/user-attachments/assets/bc8e90bc-23d8-40af-942e-f8f4405b483a



You can switch between the two visualizations by pressing the **left** and **right** arrow keys
